### PR TITLE
DRAFT ScriptEditor UI Fixes

### DIFF
--- a/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
@@ -73,6 +73,7 @@ import PanelInstances from './components/PanelInstances';
 import PanelMessage from './components/PanelMessage';
 import DialogConfirm from './components/DialogConfirm';
 import { SKIP_RELOAD_WARNING } from 'config/gem-settings';
+import Dragger from './components/Dragger';
 
 /// WIZ GUI PANELS ////////////////////////////////////////////////////////////
 import ScriptView_Pane from './wiz/gui/ScriptView_Pane';
@@ -141,7 +142,8 @@ class ScriptEditor extends React.Component {
       monitoredInstances: [],
       message: '',
       messageIsError: false,
-      selection: ''
+      selection: '',
+      scriptWidthPercent: 50
     };
     this.CleanupComponents = this.CleanupComponents.bind(this);
     this.Initialize = this.Initialize.bind(this);
@@ -159,6 +161,8 @@ class ScriptEditor extends React.Component {
     this.PostSendMessage = this.PostSendMessage.bind(this);
     this.OnDebugMessage = this.OnDebugMessage.bind(this);
     this.HandleConfirmReload = this.HandleConfirmReload.bind(this);
+    this.OnDraggerUpdate = this.OnDraggerUpdate.bind(this);
+
     // Sent by PanelSelectAgent
     UR.HandleMessage('SELECT_SCRIPT', this.SelectScript);
     UR.HandleMessage('NET:SCRIPT_UPDATED', this.HandleScriptUpdate);
@@ -502,6 +506,10 @@ class ScriptEditor extends React.Component {
     this.SelectScript(); // force selector
   }
 
+  OnDraggerUpdate(ratio) {
+    this.setState({ scriptWidthPercent: ratio * 100 });
+  }
+
   /*  Renders 2-col, 3-row grid with TOP and BOTTOM spanning both columns.
    *  The base styles from page-styles are overidden with inline styles to
    *  make this happen.
@@ -515,7 +523,8 @@ class ScriptEditor extends React.Component {
       projId,
       bpEditList,
       bpName,
-      selection
+      selection,
+      scriptWidthPercent
     } = this.state;
     const { classes } = this.props;
 
@@ -538,11 +547,15 @@ class ScriptEditor extends React.Component {
       />
     );
 
+    // Overrides PANEL_CONFIG's previously defined column proportions
+    // PANEL_CONFIG is still being used to keep track of view state
+    const GRID_COLUMNS = `${scriptWidthPercent}% auto 0px`;
+
     return (
       <div
         className={classes.root}
         style={{
-          gridTemplateColumns: PANEL_CONFIG.get(panelConfiguration),
+          gridTemplateColumns: GRID_COLUMNS,
           gridTemplateRows: '40px auto' // force hide bottom bar
         }}
       >
@@ -583,6 +596,7 @@ class ScriptEditor extends React.Component {
           )}
         </div>
         <div id="console-main" className={classes.main}>
+          <Dragger color="#064848" onDragUpdate={this.OnDraggerUpdate} />
           <ScriptLine_Pane selection={selection} />
           {/* <PanelSimViewer id="sim" onClick={this.OnPanelClick} /> */}
         </div>

--- a/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
@@ -161,6 +161,7 @@ class ScriptEditor extends React.Component {
     this.PostSendMessage = this.PostSendMessage.bind(this);
     this.OnDebugMessage = this.OnDebugMessage.bind(this);
     this.HandleConfirmReload = this.HandleConfirmReload.bind(this);
+    this.OnProjectMenuSelect = this.OnProjectMenuSelect.bind(this);
     this.OnDraggerUpdate = this.OnDraggerUpdate.bind(this);
 
     // Sent by PanelSelectAgent
@@ -506,6 +507,10 @@ class ScriptEditor extends React.Component {
     this.SelectScript(); // force selector
   }
 
+  OnProjectMenuSelect(event) {
+    this.SelectScript({ bpName: event.target.value });
+  }
+
   OnDraggerUpdate(ratio) {
     this.setState({ scriptWidthPercent: ratio * 100 });
   }
@@ -527,6 +532,28 @@ class ScriptEditor extends React.Component {
       scriptWidthPercent
     } = this.state;
     const { classes } = this.props;
+
+    const sortedBlueprints = bpEditList
+      ? bpEditList.sort((a, b) => {
+          if (a.name < b.name) return -1;
+          if (a.name > b.name) return 1;
+          return 0;
+        })
+      : [];
+    const ProjectSelectMenu = (
+      <select
+        value={bpName}
+        onChange={this.OnProjectMenuSelect}
+        className={classes.select}
+        style={{ margin: '0 20px' }}
+      >
+        {sortedBlueprints.map(bp => (
+          <option key={bp.name} value={bp.name} selected={bp.name === bpName}>
+            {bp.name}
+          </option>
+        ))}
+      </select>
+    );
 
     const DialogNoMain = (
       <DialogConfirm
@@ -567,6 +594,7 @@ class ScriptEditor extends React.Component {
           <div style={{ flexGrow: '1' }}>
             <span style={{ fontSize: '32px' }}>SCRIPT EDITOR {projId}</span>
           </div>
+          {ProjectSelectMenu}
           <button
             type="button"
             onClick={() => window.close()}

--- a/gs_packages/gem-srv/src/app/pages/components/Dragger.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/Dragger.jsx
@@ -1,0 +1,98 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  Horizontal Dragger Component
+
+      Use this component to implement a dragger bar that users can drag
+      to resize panels.
+
+  To Use
+
+      <Dragger
+        color="#FF00FF"
+        onDragUpdate={this.onDraggerUpdate}
+        onDragEnd={this.onDraggerEnd}
+      />
+
+  Properties
+      color -- the color of the dragger, can be hex or string (e.g. "blue")
+               OK to use alpha, e.g. "#FFFFFF33"
+      onDragUpdate -- continously fires during drag
+      onDragEnd -- fires on mouse up
+
+  Returns
+      Both `onDragUpdate` and `onDragEnd` returns a ratio between 0 and 1 of
+      where the dragger is relative to the screen
+      e.g. if the dragger is in the middle of the screen, the value is 0.5
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import React from 'react';
+
+/// UTILITY FUNCTIONS /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/**
+ * Returns ratio of dragger position relative to screen width
+ * @param {Object} event UI event
+ * @returns
+ */
+function calculateRatio(event) {
+  const screenWidth = event.view.outerWidth;
+  const offset = event.pageX;
+  return offset / screenWidth;
+}
+
+/// CLASS DECLARATION /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class Dragger extends React.Component {
+  constructor() {
+    super();
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.handleDrag = this.handleDrag.bind(this);
+    this.endDrag = this.endDrag.bind(this);
+  }
+
+  onMouseDown(event) {
+    event.stopPropagation();
+    document.onmouseup = this.endDrag;
+    document.onmousemove = this.handleDrag;
+  }
+  handleDrag(event) {
+    event.stopPropagation();
+    const { onDragUpdate } = this.props;
+    const ratio = calculateRatio(event);
+    if (onDragUpdate) onDragUpdate(ratio);
+  }
+  endDrag(event) {
+    event.stopPropagation();
+    const { onDragUpdate, onDragEnd } = this.props;
+    const ratio = calculateRatio(event);
+    if (onDragUpdate) onDragUpdate(ratio);
+    if (onDragEnd) onDragEnd(ratio);
+    document.onmouseup = null;
+    document.onmousemove = null;
+  }
+
+  render() {
+    const { color = 'green', onDragUpdate, onDragEnd } = this.props;
+    return (
+      <div
+        id="dragger"
+        style={{
+          float: 'left',
+          height: '100%', // horizontal dragger, so full height
+          width: '10px',
+          cursor: 'col-resize',
+          backgroundColor: color
+        }}
+        onMouseDown={this.onMouseDown}
+      >
+        &nbsp;
+      </div>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// include MaterialUI styles
+export default Dragger;

--- a/gs_packages/gem-srv/src/app/pages/helpers/page-xui-styles.js
+++ b/gs_packages/gem-srv/src/app/pages/helpers/page-xui-styles.js
@@ -321,6 +321,13 @@ const useStylesHOC = theme => ({
     borderRightColor: CLR_HI2,
     borderBottomColor: CLR_HI2
   },
+  buttonMedium: {
+    ...BUTTON,
+    fontSize: '12px',
+    minHeight: '35px',
+    minWidth: '25px',
+    borderRadius: '5px'
+  },
   buttonSmall: {
     ...BUTTON,
     fontSize: '12px',
@@ -377,6 +384,17 @@ const useStylesHOC = theme => ({
     transform: 'rotate(180deg)'
   },
   input: {
+    fontSize: '18px',
+    color: CLR_ACTIVE,
+    borderTopColor: BaseColorShift(-240, 0.2),
+    borderLeftColor: BaseColorShift(-240, 0.2),
+    borderRightColor: BaseColorShift(0, 0.1),
+    borderBottomColor: BaseColorShift(0, 0.1),
+    backgroundColor: CLR_OBJECT_CLICKABLE
+  },
+  select: {
+    minHeight: '40px', // match navButton
+    paddingTop: '3px',
     fontSize: '18px',
     color: CLR_ACTIVE,
     borderTopColor: BaseColorShift(-240, 0.2),


### PR DESCRIPTION
A few minor Script Editor improvements:

* The Script Editor now has a vertical dragger to resize the script and line views (#749):
![screenshot_1287](https://github.com/theRAPTLab/gsgo/assets/1403057/9c8d8b1a-62d7-48f1-b0af-f809cdbad723)

* Blueprints can now be selected directly in the Script Editor view (#750) via a popup menu.
![screenshot_1290](https://github.com/theRAPTLab/gsgo/assets/1403057/ec05e1bd-2bbe-4ed2-a7cb-a1da8c3f0389)
