### PR TITLE
Change wizard references from `agent` to `character`

### DIFF
--- a/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
@@ -548,7 +548,7 @@ class ScriptEditor extends React.Component {
         style={{ margin: '0 20px' }}
       >
         {sortedBlueprints.map(bp => (
-          <option key={bp.name} value={bp.name} selected={bp.name === bpName}>
+          <option key={bp.name} value={bp.name}>
             {bp.name}
           </option>
         ))}

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
@@ -158,6 +158,7 @@ export const ADVANCED_SYMBOLS = [
   'vision',
   // agent
   'agent',
+  'character', // replaces 'agent'
   'x',
   'y',
   'statustext',

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditorSelect_Block.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditorSelect_Block.tsx
@@ -11,7 +11,7 @@
   note:
   the script being rendered is using RAW scriptTokens that are being
   interpreted very simply. However, validationTokens are intepetreted using
-  the richer GEMSTEP types, so a weakness of thecurrent system is having to
+  the richer GEMSTEP types, so a weakness of the current system is having to
   constantly reconcile scriptTokens to validationTokens to figure out
   what to draw and what is the "context" of a current token in GEMSTEP terms;
   the scriptToken by itself is not sufficient. This is what the validation

--- a/gs_packages/gem-srv/src/lib/class-keyword.tsx
+++ b/gs_packages/gem-srv/src/lib/class-keyword.tsx
@@ -434,9 +434,17 @@ function K_DerefProp(refArg): DerefMethod {
     };
   } else if (len === 2) {
     /** EXPLICIT REF *******************************************************/
-    /// e.g. 'agent.x' or 'Bee.x' or 'global.x'
+    /// e.g. 'agent.x' or 'Bee.x' or 'global.x' or 'character.x'
+    /// 2023-08 UPDATE: team requested use of `character.Costume` instead of
+    ///                 `agent.Costume`, so we map `character` to `agent`
+    ///                 during compile time.
     deref = (agent: IAgent, context: any) => {
-      const c = ref[0] === 'agent' ? agent : context[ref[0]];
+      // ORIG CODE
+      // const c = ref[0] === 'agent' ? agent : context[ref[0]];
+      // NEW CODE 2023-09
+      // if script refers to `character` in wizard, replace the 'character'
+      // reference with `agent` during compile.  See #762
+      const c = ref[0] === 'character' ? agent : context[ref[0]];
       if (c === undefined)
         throw Error(
           `context missing '${ref[0]}' key. Agent is ${JSON.stringify(

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/featCall.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/featCall.tsx
@@ -48,7 +48,7 @@ export class featCall extends Keyword {
       };
     } else if (len === 2) {
       /** EXPLICIT REF *******************************************************/
-      /// e.g. 'agent.Costume' or 'Bee.Costume'
+      /// e.g. 'character.Costume' or 'agent.Costume' or 'Bee.Costume'
       /// 2023-08 UPDATE: team requested use of `character.Costume` instead of
       ///                 `agent.Costume`, so we map `character` to `agent`
       ///                 during compile time.
@@ -56,7 +56,7 @@ export class featCall extends Keyword {
         // if script refers to `character` in wizard, replace the 'character'
         // reference with `agent` during compile.  See #762
         const bpRef = ref[0] === 'character' ? 'agent' : ref[0];
-        let c = context[bpRef as string]; // SM_Agent context
+        const c = context[bpRef as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return c.callFeatMethod(ref[1], mName, ...prms);
       };

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/featCall.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/featCall.tsx
@@ -49,8 +49,14 @@ export class featCall extends Keyword {
     } else if (len === 2) {
       /** EXPLICIT REF *******************************************************/
       /// e.g. 'agent.Costume' or 'Bee.Costume'
+      /// 2023-08 UPDATE: team requested use of `character.Costume` instead of
+      ///                 `agent.Costume`, so we map `character` to `agent`
+      ///                 during compile time.
       callRef = (agent: IAgent, context: any, mName: string, ...prms) => {
-        const c = context[ref[0] as string]; // SM_Agent context
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpRef = ref[0] === 'character' ? 'agent' : ref[0];
+        let c = context[bpRef as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return c.callFeatMethod(ref[1], mName, ...prms);
       };

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/featProp.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/featProp.tsx
@@ -83,7 +83,7 @@ export class featProp extends Keyword {
       };
     } else if (len === 2) {
       /** EXPLICIT REF *******************************************************/
-      /// e.g. 'agent.Costume' or 'Bee.Costume'
+      /// e.g. 'character.Costume' or 'agent.Costume' or 'Bee.Costume'
       callRef = (
         agent: IAgent,
         context: any,
@@ -92,7 +92,9 @@ export class featProp extends Keyword {
         ...prms
       ) => {
         const featName = ref[1];
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
         const c = context[bpName as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return GetFeatPropWithDebug(c, featName, pName, mName, prms);
@@ -101,7 +103,9 @@ export class featProp extends Keyword {
       /** NEW EXTENDED REF REQUIRED ******************************************/
       /// e.g. blueprint.feature.prop
       callRef = (agent: IAgent, context: any, mName: string, ...prms) => {
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
         const featName = ref[1];
         const pName = ref[2];
         const c = context[bpName as string]; // SM_Agent context

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/featPropPop.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/featPropPop.tsx
@@ -45,9 +45,15 @@ export class featPropPop extends Keyword {
       };
     } else if (len === 2) {
       /** EXPLICIT REF *******************************************************/
-      /// e.g. 'agent.Costume' or 'Bee.Costume'
+      /// e.g. 'character.Costume' or 'agent.Costume' or 'Bee.Costume'
+      /// 2023-08 UPDATE: team requested use of `character.Costume` instead of
+      ///                 `agent.Costume`, so we map `character` to `agent`
+      ///                 during compile time.
       callRef = (agent: IAgent, context: any, pName: string, arg) => {
-        const c = context[ref[0] as string]; // SM_Agent context
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpRef = ref[0] === 'character' ? 'agent' : ref[0];
+        const c = context[bpRef as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return c.getFeatProp(ref[1], pName).setTo(arg);
       };
@@ -55,7 +61,10 @@ export class featPropPop extends Keyword {
       /** NEW EXTENDED REF REQUIRED ******************************************/
       /// e.g. blueprint.feature.prop
       callRef = (agent: IAgent, context: any, arg) => {
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
+        // const bpName = ref[0];
         const featName = ref[1];
         const propName = ref[2];
         const c = context[bpName as string]; // SM_Agent context

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/featPropPush.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/featPropPush.tsx
@@ -35,9 +35,15 @@ export class featPropPush extends Keyword {
       };
     } else if (len === 2) {
       /** EXPLICIT REF *******************************************************/
-      /// e.g. 'agent.Costume' or 'Bee.Costume'
+      /// e.g. 'character.Costume' or 'agent.Costume' or 'Bee.Costume'
+      /// 2023-08 UPDATE: team requested use of `character.Costume` instead of
+      ///                 `agent.Costume`, so we map `character` to `agent`
+      ///                 during compile time.
       callRef = (agent: IAgent, context: any, pName: string, mName: string) => {
-        const c = context[ref[0] as string]; // SM_Agent context
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpRef = ref[0] === 'character' ? 'agent' : ref[0];
+        const c = context[bpRef as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return c.getFeatProp(ref[1], pName)[mName];
       };
@@ -45,7 +51,9 @@ export class featPropPush extends Keyword {
       /** NEW EXTENDED REF REQUIRED ******************************************/
       /// e.g. blueprint.feature.prop
       callRef = (agent: IAgent, context: any, mName: string) => {
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
         const featName = ref[1];
         const propName = ref[2];
         const c = context[bpName as string]; // SM_Agent context

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/ifFeatProp.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/ifFeatProp.tsx
@@ -70,7 +70,9 @@ export class ifFeatProp extends Keyword {
         ...prms
       ) => {
         const featName = ref[1];
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
         const c = context[bpName as string]; // SM_Agent context
         if (c === undefined) throw Error(`context missing '${ref[0]}'`);
         return GetFeatPropWithDebug(c, featName, pName, mName, prms);
@@ -79,7 +81,9 @@ export class ifFeatProp extends Keyword {
       /** NEW EXTENDED REF REQUIRED ******************************************/
       /// e.g. blueprint.feature.prop
       deref = (agent: IAgent, context: any, mName: string, ...prms) => {
-        const bpName = ref[0];
+        // if script refers to `character` in wizard, replace the 'character'
+        // reference with `agent` during compile.  See #762
+        const bpName = ref[0] === 'character' ? 'agent' : ref[0];
         const featName = ref[1];
         const pName = ref[2];
         const c = context[bpName as string]; // SM_Agent context

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/class-expr-evaluator-v2.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/class-expr-evaluator-v2.ts
@@ -61,6 +61,10 @@ class ExpressionEvaluator {
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   evaluateMember(node, context) {
+    // hack to to support use of 'character' instead of 'agent' in ifExpr
+    // expressions
+    if (node.object.name === 'character') node.object.name = 'agent';
+    // end hack
     const object = this.evaluate(node.object, context);
     if (node.computed) {
       return [object, object[this.evaluate(node.property, context)]];

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
@@ -1107,6 +1107,8 @@ class SymbolInterpreter {
     }
     bpName = bpName === 'character' ? agentName : bpName; // map 'character' to the current bundle's bpName (was `agent`)
     // inject `character` matching the current agent name
+    // Originally `agent` was used to refer the current agent but the team
+    // wanted to replace `agent` with `character`.
     const agent = { character: SIMDATA.GetBlueprintBundle(agentName).symbols };
     blueprints = { ...blueprints, ...agent };
     const bp = blueprints[bpName] || {};

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
@@ -1105,11 +1105,9 @@ class SymbolInterpreter {
         propName = cleanedPropRef;
       }
     }
-    bpName = bpName === 'agent' ? agentName : bpName; // map 'agent' to the current bundle's bpName
-    // inject `agent` matching the current agent name
-    const agent = {
-      agent: SIMDATA.GetBlueprintBundle(agentName).symbols
-    };
+    bpName = bpName === 'character' ? agentName : bpName; // map 'character' to the current bundle's bpName (was `agent`)
+    // inject `character` matching the current agent name
+    const agent = { character: SIMDATA.GetBlueprintBundle(agentName).symbols };
     blueprints = { ...blueprints, ...agent };
     const bp = blueprints[bpName] || {};
     const props = bp.props;
@@ -1127,9 +1125,9 @@ class SymbolInterpreter {
     // we want to use our custom symbol dict for processing
     this.setCurrentScope(symbols);
     // check validity
-    // PART 1 should be agent or Blueprint
+    // PART 1 should be agent 'character' or Blueprint
     const goodBlueprint =
-      bpName === 'agent' || SIMDATA.HasBlueprintBundle(bpName);
+      bpName === 'character' || SIMDATA.HasBlueprintBundle(bpName);
     // Part 2 should be valid propName
     const prop = props[propName];
     const goodProp = props[propName] !== undefined;
@@ -1179,9 +1177,9 @@ class SymbolInterpreter {
     }
     let [bpName, featureName, propName] = propRef;
     let blueprints = SIMDATA.GetBlueprintSymbols();
-    // inject 'agent' matching the current bundle
+    // inject 'character' matching the current bundle
     let agentName = this.getBundleName(); // fallback to bundle
-    const agent = { agent: SIMDATA.GetBlueprintBundle(agentName).symbols };
+    const agent = { character: SIMDATA.GetBlueprintBundle(agentName).symbols };
     blueprints = { ...blueprints, ...agent }; // add the blueprint for "agent" also
     // Catch propRef = "undefined" string
     // When first adding a featProp line, 'token' will be "undefined"
@@ -1265,9 +1263,9 @@ class SymbolInterpreter {
     // figure out what we got
     let [bpName, featureName, methodName] = propRef;
     let blueprints = SIMDATA.GetBlueprintSymbols();
-    // inject 'agent' matching the current bundle
+    // inject 'character' matching the current bundle
     const agentName = this.getBundleName();
-    const agent = { agent: SIMDATA.GetBlueprintBundle(agentName).symbols };
+    const agent = { character: SIMDATA.GetBlueprintBundle(agentName).symbols };
     blueprints = { ...blueprints, ...agent };
     if (tokType === 'identifier')
       return this.badToken(token, { blueprints } as TSymbolData, {


### PR DESCRIPTION
References to `agent` in ScriptEditor / line editor should now properly refer to `agent` instead of `character`.

For example:

![screenshot_1294](https://github.com/theRAPTLab/gsgo/assets/1403057/8e498dd7-4bfa-4cd3-b7e7-b349dbb06e23)

Addresses #756 