### PR TITLE
Feature: Bookmarks and custom styles

### DIFF
--- a/_ben_log.md
+++ b/_ben_log.md
@@ -1,0 +1,2501 @@
+# Setting up -- 2022-0326
+
+* `load_proj('local')` seems weird?  'project' vs 'sets of assets'
+  `load_proj('AEP')` doesn't work? 
+
+* Moths Parameters: https://gitlab.com/stepsys/gem-step/gsgo/-/wikis/Design/MothsParameters
+  --  It's useful to them if they can just demo and talk through
+  
+* moth3:110: `ifExpr...else` is not implemented yet?
+
+* Example hard problems:
+  --  physics dependent on costume
+  --  Figuring out how to coordinate physics and costume sizing for students
+      --  You don't necessarily want them to worry about setting both physics and costumes.
+      --  So it's like you have two levels of scaffolding: one the higher order abstract
+          that takes care of things for you, and another, the low-level that allows you to 
+          customize behaviors.
+      
+# features symbol selection -- 2022-0312
+
+PRB ScriptEditPane
+    
+    
+# ac/dc -- 2022-0425
+
+PRB Pure Data dc-project
+
+TDO 
+* dc-project
+  PRB Perhaps dc-project really isn't a dc-class?
+      It's closer to a project manager class?
+  TODO
+  --  Remove PROJECT and ASSETS
+  --  m_LoadProjectFromAsset should be moved to ac-project?
+  --  m_FileWriteProject should be moved to ac-project?
+  --  m_UpdateProjectFile should be moved to ac-project?
+  --  CreateFileFromTemplate should be moved to ac-project?
+  
+LOG
+    DO  project-server
+        * Remove DC_LOAD_PROJECT call.
+        ac-rounds
+        * We need to do two update all the time?
+          --  update dc-project with latest data
+          --  trigger a project write with ac-project
+              =>  But how?  What should the messaging be?
+                  via UR call?
+                  via import?
+                  --  Can ac-rounds import ac-project?
+                  --  Or have ac-project subscribe to ac-rounds?
+                  --  Or does dc-project initiate anything?
+                  --  Or set a ac-rounds.parent = ac-project?
+          --  m_UpdaterProjectFile is being called twice?
+              --  Once by bleuprints
+              --  Once by instances
+        --  expres-assets --- AsetUpdate_Middleware is not being called?
+            --  saves are not happening?  No errors?
+            --  works in tmp/gsgo
+            --  how about dev-next-gui?  Yes works.
+            --  So the recent changes broke something.
+            =>  Was using an async call when it wasn't necessary.
+
+# ac/dc -- 2022-0426
+
+PRB blueprint for 'BlockID' not defined -- transpiler-v2:129
+    --  MakeAgent should be using bpname, not bpid.
+    --  simagents:160
+PRB Does anyone actually use the gemproj blueprint id?
+PRB ac-project / PanelProjectEditor updates should not result
+    in a complete project update!  Since it only edits project metadata
+    and project label data?
+
+DESIGN
+* ac-project
+  --  Should it be the main project data module?
+  --  How should it handle label/id updates vs actual project data updates?
+  --  PanelProjectEditor changes are not currently being saved!
+  
+# ac/dc -- 2022-0427
+
+PRB Add new character instance -- 
+    project-server.InstanceAdd:427
+    =>  ac-blueprints referencing removed 'blueprints' key
+
+NEXT Reconcile use of 'blueprints' in ac-blueprints.
+    --  Should it be bundles or blueprintText?
+        How do we know which to use when?
+    --  ScriptEditor is not able to load script
+        Because the project 'model' has the wrong data?
+        Really we just want DCENGINE.GetAllBlueprintBundles
+        We don't need the whole model?
+    QA  Select Character Script to edit
+        --  PanelBlueprints.OnBlueprintClick:50
+            ScriptEditor.RequestModel
+              project-server.ReqProjData
+              project-server.HandleRequestProjData
+              project-server.ReqauestProject
+              ACProject.GetProject()
+            Needs
+              --  scriptId
+              --  GetBlueprint should probably return DICT?
+                  so we can look up blueprints by name?
+              --  ScriptEditor needs blueprint text for display too.
+              --  ScriptEditor only needs blueprint name to look up 
+                  specific blueprint.
+              --  Should ScriptEditor talk to dc-script-engine directly?
+                  Probably not?  We want project-server to be the interface?            
+        Add new Character Instnace
+        --  INSTANCE_ADD project-server:427
+    
+# ac/dc -- 2022-0428
+DES Start with what project-server.RequestBpTextMap hsould return!
+  --  It can't return a dict!  So it should return either an object
+      or an array.
+DES Think also of what the various blueprint data objects are:
+  --  gemproj bp defs
+      {
+        name: 'BlockPragma',
+        scriptText: '# BLUEPRINT BlockPragam',
+        editor: undefined
+      }
+      --  Define this in tscript.d?
+  --  bpBundles
+QA ac-blueprint.UpdateBlueprint
+QA ac-blueprint.DeleteBlueprint needs to be rewritten to take care of BPTEXTMAP
+QA ac-blueprint saves are not being saved to the project file?!?!
+    --  PanelScript.SCRIPT_UPDATE
+    --  project-server.ScriptUpdate
+        --  ACBlueprints.UpdateBlueprint
+        --  ACBlueprints.updateAndPublish(blueprints)
+    --  When should writes happen?  Part of the hook_Effect only?
+        --  Explicitly request during Update and Delete?
+        --  What does projectFileRequestWrite actually write?
+            DCPROJECT keeps what kind of blueprint?
+            Blueprints aren't updating DCPROJECT?
+            or DPCPROJECT needs to update itself before writing?
+        --  updateAndPublish should be udpting DCPROJECT.
+
+# ac/dc -- 2022-0429
+QA  Renamed bp does not remove old instances until reload
+DO  ac-bluerpint:453
+    --  convert loaded blueprints {id,label,scriptText} into simplified {name,scriptText}?  Or do we leave it alone?
+    --  We're partially doing it now.
+QA  Delete Instance is not removed from sim
+    InstanceEditor.OnDeleteInstance
+    LOCAL:INSTANCE_DELETE
+    project-server.InstanceDelete
+    --  DCAgents.DeleteInstance
+    --  DCAgents.DeleteAgent
+    What do we call when we add an instance?
+    --  INSTANCE_ADD
+    --  project-server.InstanceAdd
+        --  AddInstance
+        --  RaiseModelUpdate
+        --  RaiseInstancesListUpdate
+QA  Delete/rename blueprint should immediately remove instances
+    RES What is the key call that will remove agents?
+        * sim-agents.AllAgentsProgram?
+          --  Converts script to instances.  
+              SCRIPT_TO_INSTANCE will remove instances.
+          --  Who calls it?
+              ALL_AGENTS_PROGRAM
+              mod-sim-control.SimPlaces
+              --  instancesSpec is drawn from ACInstances.GetInstances
+                  =>  The instance spec is correctly pared down.
+                  =>  SCRIPT_TO_INSTANCE correctly calls onRemove
+        * But the agent itself is not removed?
+    RES How are we handling agent deletion from InstanceEditor?
+        --  Because that works.
+        --  project-server.InstanceDelete calls
+              ACInstances.DeleteInstance(data.id);
+              DCAgents.DeleteInstance(data);
+              DCAgents.DeleteAgent(data);
+
+QA  APP_START cannot read property of undefined (id)
+    --  project-server.Initialize()
+        ACProject.LoadProjectFromAsset
+        --  dc-project.ProjectFileLoadFromAsset
+            --  as-load-project.getProjectByProjId:208
+                => For some reason the asset is missing `.rsrc`!!!
+    --  http://localhost/assets/local/projects/
+        --  lists 'blocks.gemprj'
+        --  But downloading it is empty!
+        TRY Restart npm run gem
+    =>  Culprit is in bad blocks instances!
+        --  Deleting instances loads it?
+        --  Delete id: 4 => FAIL
+        --  Delete id: 3 => FAIL
+        --  Delete id: 3,4 => OK
+        --  Change id2 SmallBlock to BlcokPragmaNew => OK
+        --  Change id 3,4 to SmallBlock => FAIL
+        --  Add initScript to 3,4 => OK
+    =>  Culprit is empty initScripts!!!
+        =>  regexp seems to not properly match tempty strings
+BUG project-server renamed blueprint needs to remove instances with old name
+     or proiperly run ACInstances.RenameInstanceBlueprint()
+FIX project-server's use of ScriptUpdate
+    --  Need to remove CompileBlueprint?
+    --  Need to properly handle BlueprintDelete?  e.g. remove isntacnes
+    --  Should maybe use SymbolHelper just to extract the name?
+* Clarify PanelBLueprints' use of 'blueprints.  Is it:
+  --  an array of bpbundles?
+  --  an array of bpDefs (id, label, script)
+  --  an array of bpIdLabels {id, label}
+* Review ac-blueprints.UpdateBlueprint and DeleteBlueprint
+  --  they call UR.WriteState('blueprints') -- wtf is that?
+BUG Tracking blueprint.editor -- ScriptEditor will be disabled if someone is editing
+    --  Who is keeping track of that?
+        * PanelSelectBlueprint displays
+          --  bpEditList has .editor
+        * Who requests it?
+          --  SELECT_SCRIPT
+              --  ScriptEditor.OnSelectScript
+              bpidList is coming from ac-bluepritns.GetBpEditList
+
+# RESET STAGE -- 2022-0501
+PRB ResetStage does not reset the dcagnets and dcinstances?
+
+DES UPDATE_MODEL
+    project-server
+    --  RaiseModelUpdate
+        * [ ] Change `UPDATE_MODEL` to `UPDATE_PROJDATA`?  `UPDATE_PROJECT`?
+    Main
+    --  HandleSimDataUpdate
+        --  Source call is UPDATE_MODEL raised by
+            project-server.RaiseModelUpdate after an instance
+            is added, or script is updated.
+        =>  Rename to `UpdateProjectData`
+        =>  Move logic to either project-server or mod-sim-control
+        =>  State setting should only be setting display parameters
+            e.g. projId
+    
+CUR HACK_SIM_RESET
+    Raised by:
+    ->  PanelPlayback
+    --  Main.OnToggleRunEdit
+    Handled by:
+    ->  Main.DoSimReset
+        --    
+    
+    DES
+    PanelPlayback.HACK_SIM_RESET => SIM_RESET
+    mod-sim-control
+    --  Raise SIM_WAS_RESET
+    project-server
+    --  Handle SIM_RESET => DoSimReset
+        --  SIM STOP?
+        --  DoSeimReset
+        --  project-server.ReloadProject
+    Main
+    --  Handle SIM_RESET => Post message, set state
+        
+CUR HACK_SIM_STOP
+    Raised by:
+    ->  PanelPlayback
+    --  Main.DoSimReset
+    --  feat-timer
+    Handled by:
+    ->  mod-sim-control.DoSimStop
+    --  Main.DoSimStop
+    
+
+DES Instance Reset
+    --  DCAGENTS will delete instances
+    Who creates all the agents?
+    --  SimPlaces!
+        --  ACInstances.GetInstances()
+            =>  ALL_AGENTS_PROGRAM
+            --  sim-agents.AllAgentsProgram
+                --  SCRIPT_TO_INSTANCE.syncFromArray
+    TRY Maybe just delete instances so they start from scratch?
+        --  Works
+    ??? Should the instance deletion happen in project-server
+        or in mod-sim-control?
+        --  project-server should only focus on loading and
+            setting project settings right?
+            That way anyone can call mod-sim-control and have the 
+            sim properly reset?  It should be the main call?    
+    
+# bpName -- 2022-0505
+
+DO  When writing blueprints, where is the data pulled from?
+    --  dc-project.ProjectFileRequestWrite uses CURRENT_PROJECT
+    --  CURRENT_PROJECT is set during
+        --  UpdateProjectData
+            --  Called by ac-blueprints.updateAndPublish
+        --  SetCurrentProject
+            --  Called by ac-project.LoadProjectFromAsset
+            --  Calls ACBlueprints.SetBlueprints
+                --  Which calls compile, where 
+                    name is reset.
+DO  InjectBlueprint
+    --  blueprintDef should be name + scriptText
+    
+
+# ac-projects -- 2022-0509
+
+DES Data flow
+    1.  ProjectEditor change
+    2.  --  update 'project' state
+    3.  ac-project update
+    4.  --  update ac-projects
+    5.  --  write
+
+DES ac-blueprints
+    --  Trigger:
+        --  SetBlueprints
+        --  CompileBlueprints
+            ==> DCENGINE updated as side effect
+    ac-metadata
+    --  Trigger:
+        --  SetMetadata
+        --  updateAndPublish
+            ==> DCPROJECTS updated as side effect
+    ac-instances
+    --  Trigger:
+        --  UpdateCurrenInstance / Add/Write/Delete
+        --  WirteState
+        --  
+ISU How should ac- state deal with dc-?
+    --  Should dc- be updated with hook_Effect?
+    --  Should dc- be updated with direct API call?
+    
+DES In general, ac- projects should work like this:
+    1.  client requests state update
+    2.  ac- updates the state
+    3.  ac- hook_Filter runs
+        =>  This is where any dc- data updates should happen
+    4.  ac- hook_Effect runs
+        =>  This is where the dc- write is triggered
+        
+    Where things should NOT happen:
+    --  updateAndPublish should NOT write to dc
+        --  It should happen in hook_Filter
+    --  Set* should not write to dc
+
+STATUS
+* ProjectEditor needs to properly update ac-projects
+  and ac-rpoject
+* ac-project label updates needs to 
+* ProjectEditor should load ac-project directly?
+  or perhaps talk to project-server.
+  See what's happening with Blueprint editing or something
+  else.  
+  
+# dev-wizard UI -- 2022-0513
+
+ISU Dev Wizard
+    --  Invalidating Script Line Tokens
+        If you change the keyword, the valid slots are changed.
+        * How do you display valid options?
+    --  
+
+# dev-wizard mockup
+
+ISU Show combined props and features
+
+# LineSlot
+
+Supporting SelectEditorLineSlot (aka Slot Selector), a display of slots!
+
+* The number of slots corresponds to the validationTokens, and are variable
+  as the slots are filled in with valid/invalid complete/incomplete entries
+* validationTokens are derive from a scriptUnit (an array of IToken)
+
+We need to know the "nature" of the slots to render
+The SlotSelector ui events:
+- select slot (one at a time) - slotIndex:number
+- 
+
+Related ui events (not SlotSelector)
+- Submit when done editing - we will ALLOW invalid entry, but flag it in the UI
+- Any submission (to project server, to compile) has to obviously pass validation
+
+- each slot has
+
+  data (1)
+  the current contents of the slot (unitText)
+
+  data (2)
+
+  validation status:
+
+  displayAsValidated
+  - the current selection has no errors
+  displayAsEmpty
+  - not validated because there's no validatable content
+  displayAsVague
+  - we don't know how to validate this but it has data
+  displayAsError
+  - the current contents is illegal or causd an error
+  displayAsUnexpected
+  - overflow state (underflow is taken care of by displayAsEmpty
+
+  data (3)
+
+  selection status
+  - the current selected slot
+  - selectedViewState of each slot
+
+type Slot {
+  expectedType: name:gsType
+  viewState: valid | empty | error | unexpected | vague
+  unitText: "text representation of scriptToken"
+  dataSelectKey: slotIndexNumber starting from LINE_START_NUM
+}
+
+const line = 'prop agent.energyLevel setTO 10';
+const lineScript = TRANSPILER.TextToScript(line);
+
+const slots = WIZCORE.GetSlotViews(lineScript);
+// slots is used to render the selection thing
+
+function RenderSlot (props) {
+  line = WIZCORE.SelectedLineNum();
+  const pageLine = WIZCORE.GetVMPageLine(line);
+  const { lineScript } = pageLine;
+  const slots = WIZCORE.GetSlotViewData(lineScript);
+  tokenList = [];
+  slots.forEach(slot=>{
+    const { expectedType, dataSelectKey, viewState, unitText } = slot;
+    tokenList.push(<GTokenVariant ...slot >);
+  });
+  return tokenList blah
+}
+
+// tokens might look like this...they have the data select key
+function GTokenVariant (props) {
+  const { expectedType, dataSelectKey, viewState, unitText } = props;
+  return (
+    <div dataKey=dataSelectKey key=? ...>
+    </div>
+  )
+}
+
+// meanwhile, in ac-wizcore DispatchClick...
+add a check for another data attribute (e.g. data-selslot?)
+update state as needed 
+
+Q. How do you get the arg structure from the keyword validator?
+A. That's what Sri is writing!
+
+
+---
+# BL
+
+* EditSymbol selection should change slot def, not line
+  (at least not yet)
+* How to handle slot/token deletion?
+* How to end/exit/save line edit?
+
+# STATUS 5/25/22
+
+wizcore sloteditline should be vtokens?
+or else how can we figure out allowable values to enter?
+
+# STATUS 5/26/22
+
+As student enters data, how do we know what to show?
+vmTokens was used previously.  What are the pieces of data?
+1. Full Script Side
+  * vmPage > vmPageLine > lineScript > scriptToken
+2. Slot Editor Side
+  * keyword > syntaxLine > syntaxTokens
+  * slotEditor > slotLine > slotTokens -- includes validation as viewState?
+  * lineScript > scriptToken
+
+EditSymbol is getting list of objects from `selection`
+--  sel_validation comes from WIZCORE.State()
+--  validationTokens comes from sel_validation
+--  symbolData comes from validationTokens
+
+--  sel_validation is set during _interceptState, based on sel_linenum
+
+??  Should EditSymbol be using the selected blueprint line (left side) for
+    validation?  Or should it be using the selected slot (right side) for
+    validation?  And should it use the keyword syntax or the currently 
+    selected value?
+
+SelectEditor
+--  Renders `selection`
+    from `props`
+    from ScriptEditPane
+    from WIZCORE.SelectedTokenInfo
+
+# Merge next-gui-validate-merge -- 2022-0527
+* STATE.SendState
+* if there's an error in the validationToken, how does EditSymbol
+  know which options to show?
+  --  Handle Overflow
+* Value entry not working?
+  --  Maybe becuase of `tok.toString` call?
+  --  Or is something else going on?
+
+# Refining SelectEidtorLineSLot -- 2022-0528
+* Show disabled 
+* Save is not saving extra vtoken?
+  --  value is not being saved for some reason
+  --  input field handler is changing script_tokens?  But that is not the slot token?
+      --  THe scripChagned save is only triggered on ENTER
+      --  Somehow the 'value' is added to the 'setTo' not a separate object???
+  =>  Change Existing Value
+      slots_linescript has the right token, but not the updated value
+      script_tokens also has the right token but not updated values
+  =>  Value isn't changed until you press ENTER
+      --  ScriptChanged script_tokens has the new value!!!
+      --  SelectEditor is re-initialized with a scriptToken with the correct
+          value
+      xx  But then SElectEditor renders 118 with the wrong value?!?
+          --  probably b/c it's reading from vtok and not scripToken?
+      --  And save still leaves `slots_linescript` and `script_tokens` wrong
+  =>  The basic problem is that the `scriptToken` used by SelectEditor
+      should be the slotScriptToken, since it's changed byRef?
+      --  `scriptToken` comes out of selection
+      --  selection comes out of SelectedTokenInfo
+      --  `scriptToken` is straight out of the source `script_tokens`?
+          and refers to objects in `script_page`
+      --  What's the slot equivalent?  When we have so many different
+          token representations?
+          --  SElectEditorLineSlot gets the slot data from TRANS.VlidateStatement
+          --  So the tokens are creatd on each render.
+          --  But SelectEditorLineSlot DOESN'T handle the tokens used by
+              SelectEditor!!!
+      --  Maybe the input value editor should be in SElectEditorLInieSlot?
+          =>  NO.  It handles the line slot and the Editor, either 
+              EditSymbol or Input
+              --  The issue is maybe that the slot validation tokens
+                  need to be generated outside of SelecEditorLineSlot?
+              --  Or just that the Input needs to pass off the values
+                  to the slots_linescript?
+          =>  The main data that SelectEditorLineSlot 
+* Should State use slots_validation
+  --  with { validationTokens, validationLog }
+  --  or use sel_slot_vmtokens?
+  --  TRANSPILER.ValidateStatement returns
+      a validation object.  So let's stick with that?
+      because we need tor un it multiple times?
+* Why is SelectEditor constructor getting an outdated
+  slots_validation object?
+  --  Actually it IS getting the right object
+  --  The problem comes when the sel_linepos changes?
+* Why is class-state-mgr choking on valid states?    
+* Selecting is all wrong?!?
+* click choiceKey handler is not correctly updating the current selection?
+  --  updating the wrong slot?  slot index is off?
+  --  or auto-incrementing slotPos to +1 is
+      messing with the stored values.  
+* ERROR
+  1.  Reload
+  2.  Click 'prop'
+  3.  Change 'prop' to call
+  4.  Click 'x'
+  5.  => methodName error in previous token
+  --  Somehow the choice calls are getting 
+      weird slot info?
+* After 'x' is selected, we really should call
+  validate tokens again!
+# REVIEW
+* `sel_slot_scripttoken` is actually a validation token -- NOT a scriptToken
+* `slots_linescript` should be the main object that SlotEditor works with.
+=>  Change <button> to use local handler with an (e)
+* DispatchClick read line should use new call
+    so it reads the right line, withbloxkcs
+* ScriptChanged method needs to do something?!?!
+  --  who calls it and what are they looking for?
+* Deselect after cancel is broken
+=> Change VIEWSTATE ENUM -- TValidationErrorCodes
+* Review click handler code
+  --  Should we be updating token by reference
+      instead of creating a new object?
+      
+# Show invalid in script_page view -- 2022-05-31
+* script-to-lines.tokenOut() and lineOut() can be used
+  to insert validation
+* How do we show viewState in SelectEditorSlots?
+  --  Key data is viewState?
+  --  Where does Slot Editor get validation tokens?
+      --  slot_validation
+      --  wizcore.interfcept state
+          --  TRANSPILER.ValidateStatement
+
+# Show invalid in script_page view -- 2022-06-01
+DO  Make sure ScriptViewPane's passed GValidationToken
+    components match SElectEditorSlots'
+DO  Rename `GValidationToken` to `GValidatedToken`?
+DO  Remove top nav
+BUG Replace number with string doesn't work
+
+# overwriting prop -- 2022-06-10
+
+1. ac-blueprints.SeetBlueprints
+2. ac-blueprints.SeetBlueprints
+3. ac-blueprints.SeetBlueprints
+
+1. LoadProjectFromAsset
+
+PRB ac-blueprints.
+      m_ResetAdnCompileBluepritns
+        m_SymbolizeBluerpitns triggers first
+        m_CompileBluerpints is second
+          bpDefs map
+    The `overwriting prop` warning is coming
+    from ac-blueprints.m_CompileBlueprints
+    calling TRANSPIELR.SymbolizeBlueprints on a
+    blueprint that has already been symbolized.
+    Perhaps we either need to clear the symbols
+    first, or we need to skip the extra symbolize?
+    (Probably not skip since the changed blueprint
+    might have new symbols that need to be symbolized)
+
+# ovewriting prop -- 2022-0611
+PRB Why is SymboliozeBluerpint called twice?
+    1.  First call is ...
+    2.  Second call is m_CompileBlueprints
+
+# fix script load -- 2022-0611
+PRB class-symbol-interpreter.ts:424 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
+    at SymbolInterpreter.argsList
+    --  Seems to happen if there's only one init line
+DO  'not an object' -- show expected value below slot
+DO  gsBoolean slots are not working
+DO  How to remove extra arguments -- `DELETE` button?
+
+# add / delete -- 2022-0612
+DO  Add new line
+DO  Delete line
+PRB What should the replacement be?
+    {identifier: 'call'}
+
+# fix EditableTokensToScript -- 2022-0612
+PRB const nscript = TRANSPILER.EditableTokensToScript(lsos);
+    This line messes up block block edits
+
+# qa Line selects after blocks -- 2022-0614
+PRB Line selections after blocks are off by 1
+PRB Saving first line of block results in errors
+DO  Auto-select newly created line for editing
+
+class state manager:324
+queue effect
+look at scroll line into view
+ScrollLineIntoView
+QueueEffect
+-- look at intercept state
+
+Why isn't scroollIntoView working?
+
+# KEYWORDS -- 2022-0615
+* prop 
+* addProp
+
+# objRef -- 2022-0615
+[
+    {
+        "identifier": "prop"
+    },
+    {
+        "objref": [
+            "agent",
+            "energyLevel"
+        ]
+    },
+    {
+        "identifier": "setTo"
+    },
+    {
+        "value": 0
+    }
+]
+
+# validation tokens for prop vs featProp -- 2022-0616
+
+prop      --  should only show prop, not feature
+featProp  --  should only show feature not prop
+
+# how does ValidateStatement work -- 2022-0616
+
+ValidateStatement
+  kwp = IKeyword
+  kwp.validate
+  class-keyword.validate
+  class-keyword.validateToken
+
+# merge editable tokens -- 2022-0617
+PRB instances choke
+    --  the problem is when instances are created
+        probably related to scriptifying?
+    TRY No initscript for instance?
+        =>  Still same problem
+
+# unedefined every -- 2022-0622
+PRB scriptToken
+      identifier: ''
+    validationToekn
+      unitText = undefined
+
+# prop jsx -- 2022-0623
+PRB InstanceEditor.render()
+    TRANSPILER.ScriptToJSX
+    script-to-jsx.ScriptToJSX
+
+REV How much do existing projects make use
+    of initScripts
+    * aquatic-energy -- pos
+    * aquatic --  pos, custom props, widget
+    =>  A fair amount, but all all settings
+
+# saving scripts -- 2022-0624
+PRB beforeunload
+    --  This not the right call
+        because it only triggers when the window is about to unload
+    componentWillUnmount
+    --  This is too late!
+PRB Crappy UI Experience
+    
+# qa -- 2022-0625
+PRB SlotEditor Cancel
+    Uncaught Error: DecodeKeywordToken: tok 'undefined' is not decodeable as a keyword
+
+# QA Keyword Test -- 2022-0627
+TRY Existing Lines
+TRY New Lines
+
+# Prop objref editor -- 2022-0627
+PRB prop name should be bp.propName
+    Let EditSymbol handle both
+    
+TRY Break blueprints into dicts
+
+# 2022-0627 
+* see featObjRef for latest example of interpreter flow
+* focuse on EditSymbol, avoid changing symbol-inteprreter
+--  EditSymbol
+--  featProp
+--  class-symbol-interpreter
+        symbolScope: ['features'], // 'names of things we want to show -- features'],
+
+DES What kinds of objrefs are there?
+    propObjRef:     prop     <bp>.<propName>
+    featPropObjRef: featProp <bp>.<featName>.<featPropName>
+    featMethObjRef: featCall <bp>.<featName>.<featMethod>
+
+DES Alt
+    Can we just flatten the objref?
+    e.g. break down bp, propName into two separate slots?
+
+# 2022-0628
+PRB `prop` line results in multiple errors
+    --  class-keyword.tsx:417 K_DerefProp: objref arg is undefined (bad scriptText?)
+        =>  objref is undefined in prop.tsx
+            because the line is just `prop`.
+            So if there's an error this egregious,
+            do we not compile it?  Or do we try to fail
+            gracefully?
+        =>  Do we not allow saves of bad script?
+    --  prop.tsx:65 Uncaught TypeError: Cannot read properties of undefined (reading 'undefined')
+
+# 2022-0630
+PRB Two Cancels
+    --  Slot Editor
+    --  Script Editor
+    Do we warn about both?
+    Simultaneously?  Or one at a time?
+    Or disable until after save?
+    
+PRB Initial Update
+    
+PRB Update Tracking
+    --  ScriptEditor
+        --  Initailize
+            =>  RequestBpEditList
+        =>  handleWizUpdate
+    --  PanelScript
+        =>  handleWizUpdate
+
+Operational Modes
+--  local state
+--  mode: 
+    --  who's turned on?
+    --  who's turned off?
+    --  general operation
+    --  edit
+    --  input stages
+    --  select line
+    --  select token
+    --  add a line
+    --  delete a line
+    --  scroll
+    --  edit slot
+    --  edit script
+    --  can you click on things
+    
+
+PRB Clear slot editor after panel switch
+
+
+# 2022-0629
+PRB Locked
+    --  Shouldn't locked tokens be done on a validationToken
+        level?  Rather than purely visual lookup?
+    --  We can't lock the WHOLE line, since for controllers
+        we still need to be able to set true/false
+        and blueprint needs to be able to set name
+    --  Lock needs to happen by the keyword, not the choices
+        e.g. if # is the selected slot, we want to prevent
+        changes to another choice.
+    --  
+
+# 2022-0630
+PRB Block Insertion
+    --  Blank Line: New ifExpr / When / OnEvent
+    --  Existing Line: Edit 
+    --  Delete Line: 
+
+# 2022-0630
+PRB ifExpr
+    --  SelectEditorSlots
+        --  validationTokens: 
+              error
+              gsType: expr
+              labeL: no unitText, so fall back to gsType
+
+# 2022-0701 STATUS
+
+#### next
+PRB Overflow words are being cut off by the
+    validator for some reason.
+    THe current 
+#### stash
+next-gui-qa:wpivalidate has
+* isDirty calls
+* attempted fixes at overflow arguments -- but its wrong
+* attempted fixes at "nothing to select" padding
+
+# isDirty 2022-0707
+PRB After submitting changed script, the system update is causing
+    ScriptEditor to think the script_page is dirty.
+    --  line edits via slot editor should set dirty flag
+    --  But general edits should not
+    Dirty should be handled by WIZCORE!
+PRB What's causing all the PanelScript renders?
+    1.  ScriptEditor.OnInstanceUpdate
+        =>  Skip the instances update
+    2.  ScriptEditor.handleWizUpdate:186
+        =>  setState is always triggering even though
+            wizupdates do not pertain to ScriptEditor.
+    3.  Scripteditor.UpdateBpEditList:235
+        =>  
+PRB Switch from Code to Wizard should not dirty
+
+# slot editor dirty -- 2022-0708
+
+PRB slot_linescript_is_dirty updates do not 
+    trigger SelectEditorSlots updates
+
+DES EditorCore
+      WizCore
+      SlotCore
+      
+    See ac-wizcore-util for how supporting modules might work
+    "data-not-saved" -- not isDirty -- 'needsSaving'
+    'needsRefresh' is different
+PRB SlotCore -- when to raise needs_saving?  From 
+    ScriptEditor when script changes?  COordinat ewith WIZCORE
+
+ScriptEditor handleWizUpdate needs to recognize when slots_lienscript_is_dirty is triggered so that it updates SelectEditorSlots.        
+
+# slot editor unsaved -- 2022-0709
+PRB Add Dialog to Slot Editor
+PRB Should editorcore handle wiz and slot state updates?
+    Really it needs to, otherwise, ScriptEditor is doing it.
+    wizcore should be:
+      wizcore
+        pagecore
+        slotcore
+PRB Issue is DevWizard
+    --  Can DevWizard just switch to SLOTCORE and EDITMGR?
+        The problem is that DevWizard has to handle wizUpdate
+        and trigger a slotUpdate.
+        Ideally editorcore does that?
+    --  Can't quite handle it in editorcore?
+        --  input changes affect slots_linescript?
+            so we can't just rely on editorcore.dispatchClick
+    --  Split into slotcore and wizcore?
+        --  even if slotpos and slot_linescript is handled in slotcore
+            we still need to process line selection from wizcore
+            and have editorcore handle the changes.
+        --  Where should that happen?
+            --  Not in ScriptEditor!!!  
+            
+PRB SelecEditorSlots
+    --  Moving state handlers directly into SelectEditorSlots
+        so that we're not cascading changes down from 
+        ScriptEditor -> ScriptEditPane -> SelectEditorSlots
+    --  Should SelecEditorSlots use slotcore directly as state?
+        --  This is how wizcore was intended to be used?
+    =>  Rename SlotEditor
+
+# editorcore -- 2022-0710
+PRB In the middle of moving slotcore methods out of wizcore
+    --  Reivew SaveSLotLineScirpt, CancelSlotEdit, DeleteSlot
+        --  Can these actually be easily extracted?
+            or do they need some interaction with wizcore?
+            in which case, we need editorcore?
+        --  Or perhaps they belong in editorcore
+            instead of slotcore?
+QA  `prop agent.name` selecting `method` breaks.
+    but works with `prop agent.x`  
+    --  slot edits need to trigger re-compile
+    --  how did the old recompile work?
+    upon slot changes, we need to redo slot bundle
+    --  And not rely on wizUpdate since it's not wiz updating
+    --  The old method recompiled bundles 
+MAP Screwy Updates?
+    --  editcore
+        --  dispatchClick
+    --  wizcore
+        --  interceptState
+    --  editore
+        --  wizUpdate
+        --  slotUpdate
+    --  slotcore
+        --  interceptState
+QA `prop agent.name`
+    --  EditCore:283.DispatchClick  - SLOTCRE.SendState(newSlotState)
+        SlotEditor:113.HandleSlotUpdate - setState(vmStateEvent)
+        SlotEditor:289.render - WIZCORE.GetLineScripText(lineScript)
+        WizCore:461.GetLineScripText
+        script-tokenizer:30.StatementToText - not a statement {}
+
+# state changes -- 2022-0711
+PRB What level should init state changes?
+    --  DevWizard => script_page
+PRB Click "Touches"
+    --  Cannot convert undefined or null to object
+    ObjRefSelector:165
+    --  Happens on the SECOND click!
+    --  Happens AFTER clicking on invalid "Touches"
+        then clicking another one!!!
+        TRY interpreter doesn't provide proper
+            options after "Touches" becuase
+            "Touches" is not a valid bpName
+            so no propName options can be found.
+            =>  Just ignore bad options?
+
+# feature compile -- 2022-0713
+PRB addFeature AgentWidgets
+    featProp agent. => can't see AgentWidgets
+
+# undefined text -- 2022-0714
+PRB TokenToUnitText returns 'undefined' string
+    TokenToUnitText maps to...
+    script-tokenizer.TokenToPlainString
+    Getting from UnpackToken
+    UnpackToken deliberately adds the 'undefined' string.
+    So let's just strip it out when dislaying the input
+    
+# bp list update -- 2022-0714
+PRB PanelSelectBlueprint
+    Delete Blueprint Call is...
+      project-server.HandleBlueprintDelete
+      BlueprintDelete
+      ACBp.DeleteBlueprint
+      Updates state - bpDefs
+      bpNamesList gets updated
+    ACBlueprints state subscription
+      
+    => ScriptEditor does not get bpNamesList update.  Only project-server does.  
+    
+    Does project-server need to pass on the event?
+    
+    State update should call UpdateBpEditList
+
+# new bp -- 2022-0714
+PRB New Script
+    --  PanelSelectBlueprint
+        --  SELECT_SCRIPT, bpName: ''
+    --  ScriptEditor
+        --  OnSelectScript
+        
+# when tests -- 2022-0714
+PRB RegisterWhenTest is only called on Main?
+    
+# select script -- 2022-0716
+SHould ScriptEditor really use OnSElectScript to start up a new script?
+Is the "this.OnSElectScript" call in componentDidMount necessary?
+
+Two Seleciton methods
+1. new script -- works
+2. select existing script - broken
+
+Issue
+* When selecting from Main, what's the proper load method?
+* Should ScriptEditor load all assets directly and not rely on the bpEditList from Main?
+
+PRB new script does not call OnSelectScript
+    With regular load, who does?
+
+# bplist -- 2022-0716
+PRB ScriptEditor bplist showing deleted scripts 
+    --  ScriptView_Pane.NET:BLUEPRINT_DELETE
+    --  project-server.
+
+PRB SlotEditor/EditSymbols showing deleted scripts
+    --  wizcore.interceptState
+        TRANSPILER.SymbolizeBlueprint
+    --  BUNDLER from 'script/tools/script-bundler
+    --  SIMDATA.GetOrCreateBlueprintBundl
+    --  DeleteBlueprintBundle
+    =>  Bundle IS deleted
+        but validation list is not 
+        getting the right list?
+    PRB ScriptEditor's SIMDATA is
+        different from MAINs?
+        =>  YES
+    PRB How do we maintain parity?
+        
+PRB `untitled` bp needs be removed
+    Actually, `prevName` bp
+    =>  Upon editmgr.SaveSlotLineScript,
+        Do we?
+        --  Make wizcore handle
+            it during interceptState?
+        --  keep track of current bpName in SlotEditor?
+        --  Can't do it in wizcore
+            because we don't have 
+            access to the previous
+            name by then?
+
+# smart features -- 2022-0716
+PRB featTouches
+    --  Physics
+    featCursor
+    --  Movement
+    
+# removal -- 2022-0716
+PRB Remove
+    * PanelScript
+    * ScriptViewPane
+    * ScriptEditPane
+    * SelectEditorSlots
+    * SelectEditor
+
+# symbolize slot -- 2022-0717
+PRB script-compiler.SymbolizeBlueprint
+    --  Does it not replace the old one?
+    --  Is dc-sim-data.DeleteBlueprintBundle the right symbol bundler?
+
+NEXT
+PRB What happens when you click on 'agent'?
+    --  editmgr.dispatchClick.choiceKey
+        SLOTCORE.SendState(slots_linescript)
+        slotcore no intercept
+    --  editmgr.handleSlotUpdate.slots_linescript
+        !!! bundle gets it from wizcore!!!
+        
+    What happens when you click "Save"?
+    --  EDITMGR.SaveSlotLineScript
+        --  WIZCORE.SendState(script_tokens)
+        --  SLOTCORE.SendState(slots_need_saving)
+    --  WIZCORE.interscept(script_tokens)
+        --  delete old blueprint bundle
+        --  EDITMGR.handleWizUpdate(cur_bdl)
+            --  update slots_validation
+            
+    Where is ObjRefSelector getting validationTokesn from?
+    --  SLOTCORE.State().slots_validation
+    
+    PRB slots_bundle is not re-created when
+        you select the new line?!?
+        
+        After changing the bpName, wizcore's 
+        cur_bdl remains pointing to the old 
+        bundle?
+        
+        Somehow slotcore slot_bundle is being
+        updated with an old budnle?  by who?
+        
+        As soon as you click a differnt line the slots_bundle reverts back?
+        After saving the last one, slots budnel did not get updated?
+            
+# script Event deletion -- 2022-0716
+KEY dc-sim-data.DeleteScriptEvent
+KEY ac-blueprints.m_ResetAndCompileBlueprints
+
+# react nochange -- 2022-0718
+PRB SlotEditorSelect_Block render
+    --  shadowroot
+        --  value is correct=0
+            but shadow root shows 5
+PRB What's being called when we select a different
+    line?
+    --  EDITMGR.DispatchClick
+          WIZCORE.SendState(sel_linenum, sel_linepos)
+            WIZCORE._intercept -- n/a
+          SLOTCORE.SendState(sel_slotpos)
+            SLOTCORE._intercept -- n/a
+        EDITMGR.handleWizUpdate(sel_linenum, sel_linepos)
+          SLSOTCORE.(sel_linenum, sel_linepos)
+          
+        EDITMGR.handleSLotUpdate
+        SlotEditorBlock.HandleSlotUpdate
+        SlotEditorBlock.render
+PRB Select Slot Position
+    --  EDITMGR.DispatchClick
+          SLOTCore.SendState(sel_slotPos)
+            SLOTCORE._intercept -- n/a
+        EDITMGR.handleSlotUpdate -- n/a
+        SlotEditorBlock.HandleSlotUpdate
+          setState(vmStateEvent)
+PRB Select Choice
+    --  EDITMGR.DispatchClick
+          SLOTCORE.SendState(
+            slots_linescript
+            slots_need_saving
+          )    
+PROGRAM DEFINE
+    MakeAgent
+    
+# qa -- 2022-0719
+PRB Add Instance
+    --  Triggering sim reset because it thinks
+        the sim is running?
+        
+# safeload -- 2022-0720
+PRB project-server
+      199:ACProject.LoadProjectFromAsset
+        DCPROJECT.ProjectFileLoadFromAsset
+          PROJECT_LOADER.getProjectByProjId
+          as-load-projects.getProjectByProjId
+        ACMetadata.SetMetadata => just sets state
+        ACRounds.SetRounds => just sets state
+        ACBlueprints.SetBlueprints => skip compile, just set bpDefs
+        ACInstances.SetInstances => just sets state
+      200:SIMCTRl.SimPlaces
+    
+PRB Submit script
+    ScriptView_Pane.SendText
+      NET:SCRIPT_UPDATE
+      
+    project-server.RaiseModelUpdate
+
+# Algae is missing from bp list -- 2022-0720      
+      
+# dbgOut -- 2022-0720
+PRB Show message
+PRB Strip quotation marks from message
+    --  Where should that happen?
+        class-symbol-interpreter works with unitText from validation tok
+        which is slots validation
+        slots_validation is done in editmgr
+        TRANSPILER.ValidateStatement
+        script-compiler.ValidateStatement
+
+# Costume reset -- 2022-0720
+PRB ScriptEditor updates affect only a single blueprint
+    --  and the instances for that blueprint
+    --  But Feature Reset is in api-sim,
+        and affects all instances for all blueprints
+    =>  Do we just recompile everythign whenever
+        a new blueprint comes in?
+        --  Makes sense if other bps make refer to the current bp?
+    PRB If script update comes in during sim run
+        then reset stage ought to clear the error
+
+# New Script -- 2022
+PRB 1. Create from Main
+        PanelBlueprints
+    2. Create from ScriptEditor
+        PanelSelectBlueprint
+        
+PRB On name change
+    project-server.ScriptUpdate(data) does
+      receive 
+    SlotEditor
+      EditMgr.SaveSlotLineScript
+        WizCore.SendState(script_tokens)
+          WizCore._intercept(script_tokens)
+            name change ? SIMDATA.DeleteBlueprintBundle
+
+# Multiple Loops -- 2022-0722
+1.  Stage()
+      Main.componentDidMount
+      client-exec.SystmAppRun
+      APP_STAGE
+2.  Stage()
+      Main.componentDidMount
+      SystemAppConfig
+      project-server.Initialize
+        DoSimReset
+      
+PRB SystemAppConfig & project-server.Initailize
+    both trigger api-sim.Stage() too close to
+    each other.        
+    --  SystemAppConfig without autoRUn doesn't seem tow rok?
+    
+PRB Ideally, projserver.Initialize runs AFTER
+    api-sim.Stage() has completed.
+
+PRB Stage() is being called again before the
+    async() method is finished.      
+        
+# Rename -- 2022-0723
+PRB Rename needs to be done on both
+    * ScriptEditor bundle
+    * Main bundle
+    
+    Add a `RenameBlueprint` call?
+    Or can we just rely on one bundle
+    replacing another?
+    
+    Should ScriptEditor be the one to instigate
+    a global delete?
+    
+    Rename Sources
+    * SlotEditorBlock
+      editmgr.SaveSlotLineScript
+      wizcore._intercept(script_tokens)
+        -- detect name change
+
+    Delete Call
+    * ScriptView_Pan.OnDeleteConfirm
+      => NET:BLUEPRINT_DELETE
+
+    project-server.HandleBlueprintDelete
+    
+# Name -- 2022-0723
+PRB Mysterious `name` field
+    methodName
+    featObjRef.cur_scope(prop)
+      prop = props[height]
+      props = feature.props
+      feature = features[Physics]
+      features = blueprint.features
+      blueprint = bluepritns[bpName]
+      blueprints = SIMDATA.GetBlueprintSymbols
+        GetBlueprintSymbolsFor
+        GetBlueprintBundle
+        BLUEPRINTS
+          dc-sim-data.SaveBlueprintBundle
+            transpiler-v2.RegisterBlueprint
+              transpiler-v2.CompileBlueprint
+                CompileStatement    
+            ac-blueprints.m_CompileBlueprints
+      
+      script-compiler.SymbolizeBlueprint
+        SymbolizeStatement
+          kwp.symbolize
+            feat.symbolize
+              feat-physics.symblize
+                height: SM_Number.Symbols
+                  => class-sm-number somehow
+                     inserts a `name: 'methods'` into
+                     the `Symbols` definition?!?
+      
+    bundle
+      symbols
+        features
+          Physics
+            props
+              height
+                methods
+                  name
+                  add
+                  setMax
+                  setMin
+                  setTo
+                  setToRnd
+                  sub
+      
+# QA -- 2022-0728
+PRB Moths-Acitivty-Dont-Know
+    1. Run Round
+    2. Stop Round
+        class-sm-agent.ts:472 Uncaught TypeError: Cannot read properties of undefined (reading 'name')
+    at SM_Agent.exec (class-sm-agent.ts:472:38)
+
+    PRB On Start Round
+          class-gscript-tokenizer-v2.ts:828 Uncaught Error: KeywordFromToken: tok 'block' is not decodeable as a keyword
+          at Module.KeywordFromToken 
+        TRY Remove `//` from start of roundinitscript?
+            => NO
+        TRY Error is in `prop lightOrDark setTo dark`
+            
+# untitled agent -- 2022-0731
+PRB untitled agent when changing projects
+    ISU ScriptEditor is designed to open scripts from
+        multiple projects, but it is not fully implemented.  When you have ScriptEditor open
+        to one project and then open another project
+        what should happen?  
+        --  Display Warning:
+            "Main has loaded a new project.  Would you like to select a Character from the
+            the new project?"
+        PRB You can't really continue to work on the
+            current project because of symbolization
+            issues -- you need to symbolize the 
+            project context in order to view agent
+            information.
+        =>  The proper fix is to make ScriptEditor
+            completely independent of Main?
+            --  If we make them completely independent
+                we run into major permissions issues
+                with multiple people opening the
+                same project?
+        =>  Interim Fix?
+            --  Show warning and force reload?
+            --  Ignore?
+            --  Is it even possible to submit
+                a script to the non-current project?
+                =>  Nope!
+# graph updates -- 2022-0731
+PRB graphProp.value going to undefined?!?!
+
+# QA -- 2022-0802
+PRB Load keywordTest with global properties: PrepRound
+      script-bundler.ts:31 Uncaught Error: AddToProgramOut: call OpenBundle() before this call
+          at m_HasCurrentBundle (script-bundler.ts:31:11)
+PRB Rounds init with partial orund
+    PRB Prep Rounds Triggers
+        --  CUR_BUNDLE is undefined
+        --  sim-rounds.RoundInit
+            sim-rounds.m_RunScript
+    TRY What's the standard symbolize and compile call?
+        --  TRANSPILER.SymbolizeBlueprint(script);
+            TRANSPILER.CompileBlueprint(script);
+        TRY Can we call SymbolizeBlueprint?
+            script-compiler.SymbolizeBlueprint
+        TRY Can we use CompileBlueprint
+    TRY If we create a round bundle, where should
+        it go?  Where should it get compiled?
+        To a 'global' bundle?
+
+# Costume/Physics -- 2022-0808
+From a student's perspective, it should be a set once and forget about it.  The system should take care of physics sizing and scaling.
+
+Costume does not rely on Physics.
+But Physics does rely on Costume.
+And Touches relies on Physics.
+Touches => Physics => Costume
+
+Issues
+* Physics has separate widths:
+  --  width         -- user-set value
+  --  bodyWidth     -- calculated
+  --  costumeWidth  -- calculated
+  --  scale         -- overrides width
+
+Use Cases
+* Setting Costume
+  --  When setting costume, it should default to 
+      size of the PNG
+  --  If you want to resize it, you should be able
+      to define one dimension: `size`?
+      --  `size` is overriden by `width/height`
+  --  If you want precise sizing, use `width`
+      and `height`.
+  --  `scale` is a more advanced concept
+* Set costumeName needs to set Physics size if present?
+* Set size of costume by scale
+* Set size of costume by exact width/height
+
+Advanced Use Cases
+* Set separate physics body size
+
+Where should size/scale be set?
+* Costume: It's more natural
+* Physics should just be body?
+  --  What about collisions?
+
+# Movement -- 2022-0810
+TRY `featProp agent.Movement.moveWander setTo true`
+    =>  exclusionary is problematic.
+        you have to turn off the value for someone else
+TRY `featProp agent.Movement.movementType setTo 'wander'`
+    =>  How do you decide to stop seeking an agent?
+    --  static: (none)
+    --  wander: (distance)
+    --  edgeToEdge: (distance) (direction)
+    --  goLocation: x y
+          `featProp agent.Movement.targetX setTo 10`
+          `featProp agent.Movement.targetY setTo 10`
+          `featProp agent.Movement.movementType setTo 'goLocation'`
+          vs
+          `featCall agent.Movement setMovementType 'goLocation' 10 10`
+          vs
+    --  jitter
+    --  wanderUntilAgent: (agent)
+    --  seekAgent: (agent)
+    --  seekAgentOrWander: (agent)
+    TRY STRINGS
+`featProp agent.Movement.moveWander setTo 0` // static
+`featProp agent.Movement.moveWander setTo 5` // move distance
+`featProp agent.Movement.moveEdgeToEdge setTo 180` // direction in degrees
+`featProp agent.Movement.moveGoTo setTo '10,10'` // x,y as string
+`featProp agent.Movement.moveJitter setTo 5` // jitter distance
+`featProp agent.Movement.moveWanderUntilAgent setTo 'Tree'` // blueprint
+`featProp agent.Movement.moveSeekAgent setTo 'Moth'` // blueprint
+`featProp agent.Movement.moveSeekAgentOrWander setTo 'Moth'` // blueprint
+
+        The key would be that anytime one of these values is set, the others
+        are cleared?  But how would we know that?
+        =>  During FEATURES_UPDATE we proces the movement, and then immediately clear it?
+
+TRY FEATURES_UPDATE
+    --  Set movementType properties
+    FEATURES_THINK
+    --  Calclate movements
+    FEATURES_EXEC
+    --  Process derived properties
+    VIS_UPDATE
+    --  apply positions
+
+# seek -- 2022-0812
+* seekAgent is not working?
+  --  where is 536: options.targetType coming from?!?!
+      --  It's stored in SEEKING_AGENTS
+      --  `seekAgent` is an internal method!
+          * seekNearest
+          * seekNearestVisibleCone
+          * seekNearestVisibleColor
+* how to stop seek?
+* commit and push Movement
+
+# Block Editing 2022-0813
+* Block Editing
+* Establish a common frame rate?
+
+# Help 2022-0813
+PRB Current Help
+    * SELECTED_SLOT_TYPE_HELP
+      --  Help for the selected slot
+      --  Rendered by `EditSymbol_Block`
+      --  codex.`ForTypeInfo`
+      --  `codex-types`.yaml
+    * SELECTED_CHOICE_HELP:
+      --  Help for selected choice
+      --  Rendered by `SlotEditor_Block`
+      --  codex.`ForEditorSelection`
+      --  `codex-keyword`.yaml
+PRB Types of Help
+    info -- 
+    1.  First select slot line
+        a.  What you're seeing
+            SELECTED_SLOT_TYPE_HELP
+        b.  What ACTION to take
+            How to take action?
+        c.  What are the options you see
+        d.  What you've selected
+            --  !selected ? general instructions
+            --  selected ? selection explanation 
+    * Slot Editor Slot: SlotEditor_Block?
+      --  Select a keyword
+      --  Select a Feature
+      --  Select method
+      --  Select a feature method
+      --  Input a Value
+    * Hovered Choice Option: EditSymbol_Block
+      --  Option to choose
+    * Selected Choice Option: EditSymbol_Block
+LOG Working On...
+    --  objRef:agentProp tokenHelp
+
+# help -- 2022-0815
+* SlotEditor_Block
+  --  subsequent validation tokens are replacin the original help
+
+* EditSymbol help works for features
+  SELECTED_CHOICE_HELP should ideally 
+  also show feature help info?
+* EditSymbol popup help for keywords and methods?
+PRB EditSymbol_Block
+    --  Need context of agent line
+        in order to figure out what kind of 
+        feature methods
+    --  f_render_choices gets
+        sd = sd.methods.monitor
+        vs = vs.methods[info, items, unittext]
+    --  How are the signatures?
+        prop => methods = slot 3
+        featProp => methods = slot 3
+        featCall => methods = slot 3
+
+# help -- 2022-0816
+* HELP
+    --  Look at kw to see if it's 
+        a featProp or featCalll?
+        if so look at objref to see
+        which feature was spec'd?
+    --  Is there a better way?
+        How else can we know that it's
+        feature-related?
+        --  The symboldata and viewdata
+            tokens themselves do not have
+            that info
+  --  generic 
+        HELP.GetHelp(gsType, selectedValue)?
+        HELP.GetHelpForVToken(vtok)?
+        =>  NO!  Too specific?
+* POPUP
+  --  Popups for slot editor get cut off
+      by the top of the screen
+* Adding Movement zeroes positions!?!
+  --  Should x/y be set?
+  --  do we want to allow
+      using prop.x?
+      or do we want to force
+      the use of Movement?
+  =>  Movement should NOT be necessary to set
+      initial position!!!
+      So that means Movement should respect
+      agent.x/y setting?
+      But agent.x/y is not set until initScript?
+      So set it after?  Add an init?
+  TRY When does initScript run?
+      GLOOP_PRERUN
+      --  dc-sim-agents.DefineInstace
+* featProp property help does not work
+* Advanced symbols help is impossible to read because of opacity
+* addProp propType Help is not being read
+* "LOCKED" Help
+  --  keywords might have special syntax
+      that has to be displayed, e.g
+      `every` should explain `runAtStart`?
+  --  featMethods might also have
+      special syntax that needs to stick
+      around
+  --  What do we do?  Cascade them?
+      Make them all stick around?
+      Glue them all together?
+      How do we show them?  Separate them?
+* `String` does not match `string`
+  --  And help is broken because of it
+* TYPES OF COLORS
+  --  Syntax
+  --  Selected Information
+  --  Selected Item
+  --  Instruction -- italics, blue?
+* CONCEPTS
+  --  Slot Selection
+  --  Token Selection (value for slot)
+      --  Token Choices
+  --  Line Level editing
+* REVIEW
+  --  Should everything be routed through ForChoice?
+      Should there be ForEditorSelection?
+      How about the others?
+      Who's actually using which calls?
+
+
+# COVERAGE
+* [ ] Slot 1: Keyword
+  * [ ] -- BLANK -- needs instructions?
+  * [x] addProp
+  * [x] addFeature
+  * [x] prop
+  * [x] featProp
+  * [x] featCall
+  * [ ] if
+  * [ ] ifExpr
+  * [x] when
+  * [x] onEvent
+  * [-] every
+  * [ ] _comment
+  * [x] propPush
+  * [x] propPop
+  * [x] featPropPush
+  * [x] featPropPop
+  * [x] exprPush
+  * [x] dbgOut
+  * [-] dbgStack
+  * [-] dbgContext
+  * [-] dbgError
+* [ ] Slot 2: 
+  * [x] feature name (list of existing)
+  * [x] objRef: <agent>.<propName>
+    * [x] 1:blueprint
+    * [x] 2:feature
+    * [x] 3:featProp
+* [ ] Slot 3:
+  * [x] propType 
+  * [x] propMethod
+  * [x] featMethod
+  * [x] when conditions tests
+* [ ] Slot input:
+  * [x] prop name
+  * [x] input value
+
+* prop Algae.spawns true => ends with full ALL selectors?
+
+# ifProp -- 2022-0824
+PRB ifFeatProp dereferencing is screwy
+
+# gsName Help -- 2022-0825
+PRB Why can't we add gsName to SM_String?
+PRB Types of hover help:
+    --  slot
+    --  selected type
+    --  selected value
+
+# gsName Help -- 2022-0827
+PRB Syntax Help 'monitor' is overriding 'method'
+    --  How to get syntaxhelp to read 
+        the syntax on a feature-related call
+        instead of trying to read 
+        the type overrides?
+    --  Call is 
+        GSTYPE        method
+        SELECTEDVALUE monitor
+        PARENTLABEL   Touches
+        =>  b/c it's a feature
+            (has PARENTLABEL)
+            codex calls m_GetFeaturePropHelp which returns 'monitor' method
+    --  Do we want to use ForEditorSelection instead?
+        --  Maybe?  It is the right info.
+        --  But what about touchType?
+    1.  Use gsName
+        =>  This is correct.
+    2.  Why is gsName returning
+        monitor?  B/c unitText!
+PRB unitText is being set to "undefined"
+    Who's doing it?
+    --  Who generates validationTokens?
+        TRANSPILER.ValidateSTatement
+        script-compiler.ValidateSTatement
+        class-symbol-interpretor:1531 .argsList
+          is somehow returning 'undfeind'?!!?
+        script-tokenzier.TokenToPlainString
+        UnpackToken is doing it!
+
+# gsName / syntax Help -- 2022-0831
+ISU Symbols are static
+    The main issue is feat props?
+    Because feat methods are settable?
+    =>  methods can define arg types
+        but props cannot?
+    TRY Can we just do a codex-only
+        substitution?  
+        =>  The problem is we don't know
+            what type to use?
+    TRY Add a custom symbolize?
+PRB Define feat prop in codex-features
+    but feat method arg in codex-types
+    Two Values?
+    `featProp movementType setTo mtype`
+    --> featProp argName
+        setTo
+        --  args
+        movementTypeString
+        --  methodSig
+          --  name: setTo
+          --  args: [movementTypeString:]
+        => arg knows methodSig?
+    `featCall monitor touchType b2b`
+    --> featCall method argName
+    TRY m_GetFeaturePropHlep should work
+        How do we know to call it?
+        --  arg token knows method
+        --  we know keyword?!?
+        How does this work?
+        --  <gsName>: parent
+        --  kw: featProp undefined
+        --  obj: ObjRef 
+        --  method: setTo 
+        --  arg: string movementTypeString
+PRB SlotEditor_Block.gsNameHelp definition
+--  gsNameHelp's ForChoice call should
+    somehow trigger m_GetFeaturePropHelp
+    --  Using info from 
+    --  `gsType` will be an unkown type
+    --  `selectedValue` will be arbitrary
+    --  what should `parentValue` be?
+    --  how do we know when to trigger
+        it?  When it's a GVAR?
+--  What do we need to know?
+    --  `featName` in order to know
+        which feature to look it up from
+PRB We WANT the help defined in the codex!
+    And NOT in the features?!?
+    This way it's centralized?
+    But it's fine for the args types to be defined in the feat and class-sm
+REV Definitions are in codex => good
+    Do non-spec'd methods cascade?
+PRB `addFeature` featName prop
+    --  gsType is `feature`, but then
+        you end up looking for `feature` in 
+        codex-features, which does not make 
+        sense at all!   It should be codex-types
+    --  Is this a codex issue?
+PRB ObjRef syntax
+PRB ObjRefSelecto'rs syntax labels
+    --  featProp is broken!
+    --  What kind of codex object should it be?
+        --  it's not a codex-feature
+        --  it's not a codex-keyword
+        --  not a gvar
+        --  should be a type!
+      
+# WIKI 
+## Overview
+Notice there's a distinction between initially naming something (e.g. a new prop name) vs selecting from a list of existing prop names.
+`any*`
+`*Name`
+
+
+## Syntax
+* Keywords
+  --  codex-keywords
+* Keyword Arg
+  --  new prop name (prop) -- `addProp`
+  --  existing prop name (prop) -- `prop`
+  --  feature (objref) -- `featCall`
+  --  feature prop name (objref) -- `featProp`
+  --  expression (string) -- `ifExpr`
+  --  `ifProp`
+  --  `ifFeatProp`
+  --  any blueprint -- `when`
+  --  available event -- `onEvent`
+  --  number -- `every`
+  --  timer option (everyOption) -- `every`
+  --  agent prop (prop) -- `propPush`
+  --  agent prop (prop) -- `propPop`
+  --  feature prop (featProp) -- `featPropPush`
+  --  feature prop (featProp) -- `featPropPop`
+  --  expression string -- `exprPush`
+  --  string -- `dbgOut`
+  --  `dbgStack`
+  --  `dbgContext`
+  --  `debgError`
+  LOOKUP  
+  --  codex-gs-args
+  --  keyword definition's validate function
+      --  look up symbol-interpreter's call
+  --  symbol-interpreter defines arts
+* GVars
+* Feature Prop (Typed GVars)
+* Feature Methods
+* Feature Method Args (Typed GVars)
+
+ISSUES
+* There isn't a one-to-one mapping between the
+  gsName, the syntax display, and the object typ
+  (gsArg type?)
+  --  e.g. prop "agent prop:prop"
+      e.g. addProp "new prop name:prop"
+
+# refinement -- 2022-0901
+PRB Should syntaxHelp use something other than ForChoice?
+    It should favor info over input?
+# refinement -- 2022-0901
+`numeric value` -- shuld be `number`?  `number value`?
+What should selected help be?
+
+
+# NEXT
+REV REVIEW KEYWORDS
+        <kw-def>       <interpreter>  <cxgsargs> 
+`addProp` => WORKS
+    --  simplePropName:simplePropName:`new prop name`
+         =>  change to `prop name`
+        ObjRefSelector uses `prop` for existing
+    --  anyPropType:  anyPropType   `pick type`
+        =>  `propType`
+        ISU selected propType returns help for the 
+            propType, including input help
+            But it should be propType selection help
+            --  Instructions are using gsTypeHelp
+                gsTypeHelp is (propType, number)
+`addFeature` => WORKS
+`prop` => WORKS
+    --  agentObjRef:  agentObjRef: `agent prop`
+        =>  change to `prop`
+        =>  objref types are defined in the ObJRefSelector
+            --  `select blueprint`
+            --  `select prop`
+`featProp` => WORKS
+    --  featObjRef:   featObjRef:   `feature prop`
+        =>  change to `select feature prop`
+        =>  objref types are defined in the ObJRefSelector
+            --  `select blueprint`
+            --  `select feature`
+            --  `select feature prop`
+`featCall` => WORKS
+`ifExpr`=> WORKS
+`when` => WORKS
+`onEvent` => WORKS
+`every` => WORKS
+    --  generic number! anyNumber
+`propPush` => WORKS
+`propPop` => WORKS
+`featPropPush` => WORKS
+    --  'select feature prop` is used in two places!
+        --  ObjRefSelector is correct
+        --  But SlotEditor lookup is not
+            because 
+`featPropPop` => WORKS
+`exprPush` => WORKS
+`dbgOut` => WORKS
+`dbgStack` => WORKS
+`dbgContext` => WORKS
+`dbgError` => WORKS
+`_comment`
+    --  not editable
+    --  
+
+TYPES OF HELP
+  --  define a name (set to a name? name a prop?)
+  --  `set` a property to a value
+  --  `select` an existing value
+  --  
+
+TRY pass keyword + featName + method parent with each
+    HELP.ForChoice call?
+    --  How much are we duplicating between SlotEdit and ObjRef and EditSYmbol?
+TRY What do we need to know?
+    * keyword
+    * featName
+    * currentToken: method vs gvar ?    
+TRY Can we fallback from subtype to standard type?
+    --  Do we do this in codex?  Or sloteditor?
+PRB Help should use class-sm-number's method definitions?  Not the hack in codex-types?
+PRB How to display popup centered on panel?
+
+# ai logging -- 2022-0904
+* ProjectSelection
+* OpenMain, OpenViewer, OpenController, OpenScriptEditor
+* SimRun
+  --  Reset
+  --  Prep Round
+  --  Pick Characters
+  --  Start
+  --  Stop Round
+
+# agent 'u' bug -- 2022-0904
+PRB 'u' agent appears
+    objref shows "LOAD" and "un"
+    --  Actually it's added after
+        you click 'featProp`
+    --  After you select "Char"
+    TRY Where the heck is the 'u'
+        coming from?!?
+    TRY Why is featObjRef:1170 
+        getting a bpName 'u'?
+        =>  profef?
+        extractokenMeta?
+
+# symbolize rounds -- 2022-0824
+* Q for Sri
+  --  RoundScripts run under the global agent context.
+      We need to symbolize and bundle the global agent, and we need to symbolize and bundle the roundScripts.  
+      --  Each round is sort of like a pragma 
+          directive in that whenver we run them,
+          we retain the current global agent state
+          and do not reset the agent with each round.
+  --  See `sim-rounds` for broken script
+  --  See `wizcore`.WizardTextChagned
+      for another example?
+  --  See ac-editmgr for how to 
+      compile bundles?
+  --  See script-compiler.SYmbolizeBlueprint for example of how to open a budnler for blueprint -- use this method to open the global agent bundler?
+      
+# global agent -- 2022-0905
+PRB https://inquirium.slack.com/archives/C01J8G6FRK2/p1659471534738089
+    --  We still need it occasionally.
+    --  Ideally we don't use the Feature
+    --  Does it work from code view?        
+PRB Used to be able to add global
+    props using round script.
+    But with change to REFEREE
+    that means we can't add Globals
+    --  Do we want to just make the
+        global agent accessible by
+        everyone?  
+        => Can be confusing.
+    --  Allow REFEREE to add to global?
+        => Too much work!
+    --  Allow objrefs in addProp?
+        => Confusing!  And edge case
+           drives complexity.
+    --  `addGlobalProp` keyword?
+        => Possible.  A little cleaner!
+    TRY Can we even reference global? 
+    --  sm-agent registers it as `GlobalAgent`
+    --  but code does not like it?
+        prefers `global`?
+PRB Where should `global` agent be symbolized?
+    --  dc-sim-agents?
+        --  More of a factory
+            no real init
+    --  sim-agents?
+        --  Maybe in AllAgentsProgram
+            Yes it clears global agent!
+            Symbolize it there?!
+ISU Even if we have a separate GlobalAgent that is always accessible, we still want to access `prop global.xxx`?
+TRY agentObjRef is getting the right 
+    bundle. and it does exist.
+    But it's missing symbols somehow?
+TRY ScriptEditor does not run sim-agents
+    and AllAgentsProgram?!?
+    TRY How DOES it load agents?
+    --  UpdateBpEditList does symbolize
+    TRY Hack in symbolize for now
+        to see if this is the right place
+ISU Where should the global agent
+    script be stored?  And how does
+    ScriptEditor get to it?
+    --  If we're just using the
+        feat-global, we'd have to
+        compile and symbolize all
+        blueprints first?  But
+        even then that wouldn't 
+        symbolize for the global agent?
+    --  GlobalAgent should really
+        be treated separately?
+        So agents can access the global
+        props?
+    --  Rounds has the same problem.
+        If agents need to access round 
+        props, rounds needs to be 
+        compiled up front?
+    --  Where and how should it be
+        intialized then?
+        How do you add global props?
+        --  New `addGlobalProp` keyword?
+            =>  That does not help with
+                symbolization.  That just
+                makes things more 
+                complicated.
+        --  Defaulit 'global' script?
+            =>  All projects have it?
+                Then you treat it like
+                any other agent?
+                except that you can
+                access it globally?
+        --  The main issue is adding a prop?
+            --  REFEREEE isn't well symbolized either
+            --  Do it in Round Init?
+                =>  That doesn't work on ScriptEditor 
+                    app.  RoundInit won't run at all!
+                =>  Somehow in ScriptEditor.UpdateBpEditList
+                    we need to symbolize REFEREE as well.
+        --  Both REFEREE and GLOBAL need a script!
+            That way ScriptEditor.UpdateBpEditList can 
+            run and symbolize them.
+TRY Inject Global Blueprint
+    PRB Why is the global prop referenced in
+        K_DefefProp not the same global?
+    =>  bpDefs defined in 
+        `ac-bluepirints.SetBlueprints`
+        are just defs.  Instances are created
+        later.  And they are not connected.
+    PRB When are the defs instantiated?
+        `sim-agents.AllAgentsProgram`
+        --  InstancesSpec defines which instances
+            are going to be created.  But we
+            never spec GlobalAgent, so it isn't
+            created!
+    TRY Force creation during AllAgentsProgram?
+        PRB `ALL_AGENTS_PROGRAM`
+            Called by `mx-sim-control.SimPlaces`
+            --  SimPlaces is called by 
+                `mx-sim-control.DoSimReset`
+        PRB ac-blueprints.ResetAndCompile
+            already compiles GlobalAgent.
+            So it should be in the bundle already?
+        PRB Do we need to create a globalAgent
+            instance?
+            --  How is sim-rounds doing it?
+                REFEREE is a SM_Agent instance
+                created by global.js
+# global -- 2022-0910
+* Fix use of ASSETDIR
+* Convert 'GlobalAgent' to 'global' for consistency?    
+* Is it still necessary to inject it in agentObjRef?                
+* interpreter.agentObjRef
+  --  don't interpret `prop foo` as error?
+  =>  Won't do.
+* decomp:805:   //exprPush {{ global.getProp('energyReleasedAsHeat').value }}
+
+# video -- 2022-0911
+* setBoundary is the size of the sim playfield
+  set by the project.
+PRB Challenges with React Function Method
+    --  useEffect -- run only once!
+    --  how to handle input updates
+    --  how to maintain the var context without state?
+# video -- 2022-0912
+PRB Initial load api-render calculates the world at 512x512
+    and sets the initial scale that way.
+    api-render.SetBoundary to 800x400 is then called
+    and a new scale factor is established, BUT the new scale
+    factor does not get passed to WebCam.
+PRB Video player should be inited only once
+    And only after component is mounted
+    --  Still need to handle size updates
+        though we could hook resize.
+    --  `loop` runs continuously, copying frames
+        it needs access to the current variables?
+    --  Once the listeners are set, they can keep going
+        the problem is that `loop` vars need to be 
+        reading the current values.  So we need 
+        to use closures for that?
+    REQ * Always be centered vertically and horizontally
+        * Default 1/1 scale fills parent
+        * When parent is resized, you're also resized
+        * Can pass either a scale value or a width/height
+          or both
+        * Store/load default values
+          --  Can be done within the component?
+PRB After load locales, the meters need to be set
+    --  We can't use defaultValues for that b/c they've
+        already been set.
+    --  Do we want to hack in value setting?
+    --  Or is it better to go with controlled values?
+        And if that's the case, then how do we handle state?
+PRB Save locales
+    --  See PanelTracker
+    --  See ac-locales
+    =>  Maybe save as project data instead?
+        --  Have to save whether video is on or off
+        --  Transforms will change based on world size.
+    --  scaleX is a state variable, but inside of `loop`
+        it isn't the current state.  It is the value of scaleX
+        when `loop` was defined. 
+        --  Shouldn't the whole function (WebCam) be running
+            on every frame / update?
+            So we don't need the setTimeout?
+            we canjust run the whole sequence right before render?
+    --  Video update is really slow?  Need to increase the render frequency?
+PRB Enable/disable webcam
+    --  Ideally we do it before metadata is loadeD?
+        Or do we only create the stream after load?
+    --  UI to toggle webcam?
+# webcam -- 2022-0914
+    --  vid once off, cannot be re-enabled
+    --  save `metadata` as state instead of individual values?
+        --  add sub object `videoxform`?
+    --  Are the `play` and `loadmetadata` listeners really necessary?
+    --  Maybe `loop` needs to be defined such that we pass state to it?
+        (assuming that's even possible?)
+PRB
+    =>  Auto-save settings after 1 second!!!!
+PRB Reset alphas after toggling webcam
+    --  Key Call: 
+        `window.resize`
+        `PanelSim.setBoundary`
+        `api-render.SetBoundary`
+    --  But the webcam toggle call is...
+        `Main.WEBCAM_UPDATE`
+        `PanelSim.updateWebCamSetting`
+        `api-render.SetGlboalConfig`
+    --  So we should be able to just trigger set boundary?
+Video
+    --  switching webcam on/off does
+        not cause a RENDERER redraw, so 
+        the backgorund remains alpha'd.
+        Resizing will trigger the redraw.        
+PRB drawWidth/DrawHeight is changing.
+    --  glitchy from transfmedVideo/
+PRB Glitchy Video
+    --  Seems to be caused by multiple streams?
+        turning streams on and off repeatedly?
+PRB Agent selection/mouseover is broken
+    --  global branch drag works
+    --  webcam 10:55a works
+    --  webcam 11:01 works
+    --  webcam 11:21 works
+    =>  1:46p stillw roks
+        --  Changes to PanelSimulation are OK
+        --  Changes to ac-metadata are OK
+    --  1:47 doesn't work!?!
+    --  2:43 breaks?
+TRY AGAIN
+    --  1:46 broken!?!
+    --  11:21 works
+    --  Yes, 1:46 broken
+TRY 1:46 one by one
+    --  ac-metadata METADATA_LOAD to WEBCAM_UPDATE OK
+    --  panel simulation
+        --  add ACMetadata => OK
+        --  Add updateWebCamSetting => OK
+        =>  Add WEBCAM_UPDATE -> updateWebCamSetting
+TRY Must be the SetGlobalConfig command?
+PRB video offset by 10?        
+    main deiv needs to be absolute?
+PRB Initial scale value is 1.7, but
+    it should be about 1.1/1.2
+    Something is being set too late?!?
+* Save values in locale?
+* show values?
+PRB     --  Why is script-setting alpha for background
+        sprites not working but intScript is working?
+    
+# add broke -- 2022-0916
+PRB Call Order
+    --  `PanelBlueprints.OnBlueprintClick`
+    --  `LOCAL:INSTANCE_ADD`
+    --  `project-server.InstanceAdd`
+    --  `RaiseModelUpdate`
+    --  `UPDATE_MODEL`
+    PRB Instance turns to `global`
+TRY Revert global change -- does it work?
+    --  Already broken in global!!!
+    --  `feature-help` -- works 9/5
+        12:56p
+        73f09222c0b59974e4203b41a5d2f197f9462a1d
+    --  `rounds` -- works 9/7 9:20p 
+        3614624da17188c1bd4453b43c9053d94543e719
+    --  9/9 10:13p 63e087e303d56d97a3be1a686016feef3f9461cd
+        --  pre global get uid works
+    --  9/9 11:06 uid BROKE!
+    --  9/9 11:03 uid
+        --  Try with replacing
+            ACInstances ref
+        =>  Works, but adds a global
+            instead of regular
+            instance?!?
+TRY Why would instance
+    be created, but not
+    rendered?
+    Why would existing SETUP
+    list two 'globals'?
+TRY Are we not clearing
+    instances before AllAgentsProgram?
+TRY Why would things work
+    fine without global?
+    --  Global is created
+        automatically?
+    Should global be created automatically?
+    Should we replace it during AgentsProgram?
+    Or during creation insert the bpdef? 
+    --  Delete the global instance each 
+        AllAgentsProgram?
+    --  Need to run exec with AllAgents
+        Program because it needs to be reset
+    TRY Just duplicate the agent id?
+PRB NET:INSPECTOR_UPDATE seems to send full blueprint data?
+
+# Logging -- 2022-0920
+PRB PKT_RTLog formatting is all commas?!?!
+    17:46:17:0341 pz	id,pz7120,bpid,Fish,x,-0.24572467118948718,y,-0.6027702474130232'
+
+
+TRY EVENTS
+PROJECT
+* Create New Project
+* Open Project
+* Open SimViewer
+* Open CharController
+PROJECT SETUP: ProjSetup
+* Select Setup
+* Select Save
+* Project Settings Edit
+* Project Settings Save
+* Edit Round Script
+* Save Round Script
+* New Blueprint <bpName>
+* Add Character
+* Edit Blueprint <bpName>
+* Edit Instance InitScript
+* Save Instance InitScript
+* Drag <name> <x> <y>
+* Click Character <name> <x> <y>
+INSPECT: Inspect
+* Show Inspector <name>
+* Hide Insepector <name>
+RUN SIM: SimEvent
+* Prep Round
+* Pick Characters
+* Start Round
+* Stop Round
+* Reset Stage
+SCRIPT EDIT: ScriptEdit
+* Save to Server
+* Save Slot <linetext>
+* Cancel Save Slot
+* Delete Slot <linetext>
+* Select Choice <symbol>
+SESSION: Session
+* Viewer Connect
+* CharController Connect
+CHARCONTROL: CharCtrl
+* CharController Set Number of Entities <num>
+* CharController Select Character <bpName>
+* Drag <bpName> <entity-id> <x> <y>
+POZYX: pz (in RTLog)
+* pz id <id> bpid <bpid> x <x> y <y>
+PTRACK: pt (in RTLog)
+* pt id <id> bpid <bpid> x <x> y <y>
+TOUCH: Touch
+* Touch agentId <agentId> targetId <targetId> b2b <b2b> binb <binb> c2c <c2c> c2b <c2b> 
+
+NetPacket: 
+[
+  'data',    'msg',
+  'id',      'rmode',
+  'type',    'memo',
+  'seqnum',  'seqlog',
+  's_uaddr', 's_group',
+  's_uid'
+]
+
+PRB Add "log" button
+PRB Why is dipslaylist being logged to regular log?
+PRB Why is LogEnabled(true) not registering/logging?!?!
+
+# Bug Fixes 2022-0922
+PRB CharController
+    "Costume" Error
+PRB Touches/Physics
+    * Delete agent in SETUP in KyewordTest
+      results in "no feature named 'Physics' error
+      --  agents not deregistering with deletion
+
+# New Script -- 2022-0923
+PRB Ways of Creating New Scripts
+    --  Main: (non-SETUP) New Character Type => Opens new Window.  Broken.
+    --  ScriptEditor: Add Character Type => WORKS!
+    --  ScriptEditor: URL http://localhost/app/scripteditor?project=keywordTest&script= => Broken
+PRB New Button Approach
+    --  `SelectScript`
+PRB Blank URL Approach
+    --  
+PRB Text centering is off.
+    --  For some reason textBounds is calculated wrong until 
+        DBGOUT RESET OUTPUT COUNTER to 1000
+        dbgOut:18
+PRB Physics bug
+    --  Now the opposite problem?
+        If click on the instance in bp list,
+PRB New Character script
+    is blank
+PRB Test Pozyx Tags!!!
+    --  Why is only 7120 working?
+    --  Why are the updates so infrequent?
+        --  Review raw stream?
+
+# QA -- 2022-0926
+
+PRB `featCall Population createAgent xxx [[block]]`?!?
+    --  Why is block appearing?
+    --  And why is it invalid?
+PRB Why does pozyx take 10 secs to appear?
+    --  Partly b/c mqtt server takes forever to start up.
+    =>  REVIEW: But why aren't entities forwarded immediately?
+        Are we queuing up some number of entities before displaying them?
+    
+# Graphing -- 2022-1001
+
+PRB Use graphValue.min/max to set graph?
+    =>  No, that's the value being graphed, AND graphs might use graphProp.
+TRY Set it explicitly
+
+# Boolean -- 2022-1003
+
+PRB How toset boolean to false (not undefined)
+    ac-editmrg.UpdateSlot is the call
+    * How to set it initially?
+    * 
+
+# NEXT
+
+PRB After Send to SErver in code mode, editor returns to script selector
+
+QA  Test Scripting        
+
+
+Global
+* Make sure GlobalAgent is not added to InstancesList
+* Make sure all keywords can access global
+
+* PanelSimulation is UR/LOAD_ASSETS
+  being loaded twice?
+  
+
+`LOAD` appears as an agent sometimes?!?!
+--  On creating a new character type?
+
+_comment / note
+
+ISSUE
+  * change existing line `prop Char.scale` to `addProp xxx`
+    xxx refuses to be set as an identifier?!?
+ISSUE
+  * SelectedChoice help should be empty if nothing is selected?
+  
+ObjRefSElector help should show last selected item.
+
+Boolean 'true' method screws up the UI
+
+Need to differentiate between comparators/gets and setters?
+
+
+
+# NEXT (after HELP)
+
+* Save Cancel
+  --  Add a "Don't Save" button?
+
+      --  
+          
+
+* Defining global properties in rounds
+
+# How to deal with extra parms
+
+# NEXT
+file DevWizard issue
+
+# stream error
+LOG Start 9:30am-ish
+    Main:         UADDR_05
+    ScriptEditor: UADDR_03
+
+# NEXT
+GIT Merge Error branch
+DES Gracefully handle script fails
+    --  How to fix/update without having to reload npm?
+    --  Undo?
+    --  Saved versions?
+    
+
+QA  `prop agent.name` selecting `method` breaks.
+    but works with `prop agent.x`  
+    =>  `name` should NOT be listed at all as a prop!!!
+
+QA  Test saving
+QA  Initial load should not enable Save button
+
+
+# STATUS
+DO  Add Feature object ref insertion (e.g. Costume.costumeName)
+
+PRB validation tokens being returned for "Costume.costumeName"
+    appear to be feature oriented (e.g. returns props and methods of the feature), rather than prop oriented (e.g. returns agent and feature props)
+    
+    culprit might be script-compile.ValidateStatement?
+    --  Somehow it is looking at feature instead of prop?
+
+
+      
+# TO DO
+* Make sure scripts are encoding quotes properly
+* Sri req
+  => Revisit 1-based vs 0-based -- is it possible to change
+     all refs to be 1-based?
+     -- transpiler.ValidateStatement would have to return
+        1-based validationTokens
+     -- TWO issues:
+        1. linePos is 1 based
+        2. slotPos is 1 based
+        
+      
+* Discuss error code
+  --  e.g. 'prop x setTo' change to 'prop costumeName setTo'
+           why is 'setTo' method vague?  it should be OK?
+           unless number setTo is different from string setTo?
+           
+
+# STATUS
+
+
+
+
+# NEXT
+
+TDO Review ac-instances
+    --  WriteState calls
+        ..hook_effect
+        ..updateAndPublish -- so state is updated twice?!?
+
+
+QA  --  'project' label edit works
+    --  'project' metadata edit works
+    --  'bpName' change during script edit
+        --  old bp is removed
+        --  new bp is added
+        --  old instances are removed
+    --  'instances' can be added
+
+REVIEW
+* How should ac-projects work?
+    --  Should it allow loading multiple projects?
+    --  e.g. if scriptEditor is requesting a script from a different project?
+    --  When you are requesting a different project to load, how should the
+        request be structured?  Who holds it?
+        Or does ac-project work with any arbitrary project?
+
+TODO
+* RESET STAGE doesn't seem to work?
+FIX project-server.ScriptUpdate should use SymbolHelper to extra name, 
+    not Compile
+
+TODO
+* ac-project
+  --  Rename 'project' state data to 'projLabel'?  
+* ac-blueprints
+  --  Remove use of id and label?  And just rely on bndl.name?
+
+
+
+TODO
+* as-load-projects
+  --  getProjectBlueprintsList is using bp id
+      --  who calls this?
+* script-extraction utilities
+  --  can use SymbolHelper class
+  --  can reference symbols inside the bundles
+
+
+
+# 2023-0208 Debug distanceTo not calculated
+Error:  m_FindNearbyCharacters skipping ${agent.blueprint.name} ${agent.id} because distanceTo was not yet calculated by SIM/PHYSICS_UPDATE.
+See https://inquirium.slack.com/archives/C01J8G6FRK2/p1675860134324419
+
+PRB Why is m_FindNearbyCharacters being called?
+    --  m_FeaturesThinkSeek
+        --  m_FeaturesThink < Hook phase SIM/FEATURES_THINK
+    
+PRB When they touch, finchesSmall is set to seek scientist
+PRB Call Order
+    --  m_PhysicsUpdate
+        m_FeaturesThink
+    --  m_FeaturesThink
+          m_FeaturesThnkSeek
+            m_FindNearybyCharacters
+              => ERROR b/c agent.distanceTo not set
+
+PRB When does SEEKING_AGENTS get updated?
+    --  At seekNearest call
+    --  The problem is that seekNearest is set BETWEEN
+        the PHYSICS UPdate nad the THINK
+
+PRB m_FeaturesThink.SEEKING_AGENT is deleting the finch
+    b/c the finch's movement type is set to edgeToEdge
+
+SUM m_FeaturesThink is deleting the finch b/c the 
+    finche's movementType is `edgeToEdge` during the
+    Think phase.
+    Setting 
+
+
+# 2023-0701 Resize Script Editor
+# 2023-0701 Edit Comments
+* SlotEditor_Block is the main component?
+  --  Should coments be treated like "Number" input fields?
+      --  There's already a keyword, so don't need to select other keyword?
+      --  Add some kind of generic text editor?
+  --  Look for id="SEB_slots" in SlotEditor_Block renderer
+      --  data is coming from `tokenList`
+          which is constructed during the render pass
+      --  How is selcting a variable value (token) diff from how comments
+          are being selected?
+      --  Dump validationTokens?  Where are they being genreated? What do they look like?
+          
+# 2023-0804 Resize Main
+* Hide MESSAGES
+    
+# 2023-0815 `agent` references
+* ScriptEditor => select blueprint 'agent'/'global'
+  --  ObjRefSelector_Block
+  --  VSDToken.blueprints
+      lists `agent` and `global`
+      --  Who's adding the list of blueprints?
+          --  It's not in bpNamesList in ac-blueprints.
+          --  It's being added in VToks?
+  --  `character` results in error
+      --  error is at `detectTypeError`
+      --  script-tokenizer
+
+# 2023-0818 enum options
+* keyword types are defined in 
+  src/modules/sim/script/vars/class-sm-boolean.ts
+* How do we define options?
+/Users/loh/dev/gsgo/gs_packages/gem-srv/src/app/pages/components
+
+
+# 2023-0818 commenting
+* Comment types are defined at SharedElements.tsx
+  Types include:
+    if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
+    if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
+    if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
+    if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
+    if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
+    if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
+    if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
+    if (label.includes('🔎')) classes += ' explanationCommentBody';
+    if (label.includes('✏️')) classes += ' changeCommentBody';
+  
+
+# SHORTCUTS
+
+## Code Folding
+CMD-K CMD-0   - unfold all
+CMD-K CMD-1   - fold all to level 1
+CMD-OPT-]   - unfolde recursively from cursor ?
+CMD-OPT-[   - fold recursively from cursor ?
+
+
+
+

--- a/_ben_quickref.md
+++ b/_ben_quickref.md
@@ -1,0 +1,116 @@
+# Daily Startup
+
+`npm start` to run full system.
+
+`npm run gem`
+
+
+# Style Guide
+
+command-shift-p
+Insert Snippet
+ur-module-example
+
+# Troubleshoot
+
+List running processes
+`ps | grep urdu`
+`ps | grep _start.js`
+
+
+
+------
+
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+  
+    Example of D.Sri's Module Style
+    Designed to be more like C# in its lettercasing conventions
+  
+  
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+/// es6: import MODULEorCLASS from './module';
+///      import { A, B } from './module';
+/// cjs: const MODULEorCLASS = require('./module');
+///      const { A, B } = require('./module');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const TYPE_CONSTANT_A = 'A';
+let m_collection = [];
+
+/// MODULE HELPERS /////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** jsdoc comment
+ *  indent to align with top
+ */
+function m_Method() {
+  // helper functions for the module begin with m_PascalCase within module
+  m_collection.push('hello');
+  return 'hello';
+}
+
+/** An Extended Comment Block *************************************************\
+
+    For in-line documentation or longer explanations of key classes
+    No need to add/remove comment prefixes for each line. JUST WRITE.
+
+\*****************************************************************************/
+
+/// CLASS DECLARATION /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** jsdoc comment
+ *  indent
+class MyClass {
+  /* for declaring classes, one per file */
+  /* remove if you're making a module (see below) */
+
+  constructor() {
+    this.propertyZ = 'Z'; // class instance prop declaration
+  }
+
+  MyClassMethod() {
+    /* _NOT_ following lowercase method conventions because C# */
+    m_collection.push(this.propertyZ);
+  }
+}
+// class static declarations
+MyClass.StaticMethod = () => {
+  /* properties attached to class declaration are class-wide (static) */
+  /* and accessible by instances, but can not access instance vars (duh) */
+};
+MyClass.STATIC_CONSTANT = 'foo';
+MyClass.staticProperty = 'bar';
+
+/// PUBLIC METHODS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** jsdoc comment
+ *  indent
+ */
+function PublicA() {}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** jsdoc comment
+ *  indent
+ */
+function PublicB() {}
+
+/// PHASE MACHINE DIRECT INTERFACE ////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+UR.HookPhase('MACHINE','PHASE',(...args)=>{
+  /* optionally return Promise to hold phase (e.g. asset loading) */
+})
+
+/// INITIALIZATION ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// any code that runs when module is loaded
+(function(){
+  /* use immediately-invoked function express (IIFE) for scope safety */
+  /* though you probably don't need to */
+})();
+
+/// EXPORTS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// es6: export default MODULEorCLASS;
+///      export { PublicA, PublicB };
+/// cjs: module.exports = MODULEorCLASS;
+///      module.exports = { A, B };

--- a/docs/_ben_acdc_notes.md
+++ b/docs/_ben_acdc_notes.md
@@ -1,0 +1,59 @@
+ac/dc Project API
+
+Key Questions
+  * Are projects stored under a single ac - project / dc - project instance ?
+  Or are they stored separately in each submodule ? e.g.ac - blueprints keeps
+  track of projId at the top level
+
+
+dc-projects
+  PROJECTS
+  CURRENT_PROJECT
+  CURRENT_PROJECT_ID
+
+  SetProject(projData)
+  SetCurrentProject(projData)
+  GetProject(projId)
+  GetCurrentProject()
+  
+  UpdateProjectData(projData)
+  
+  ProjectFileRequestWrite(projId)
+  ProjectFileCreateFromTemplate(templateId, newfilename)
+  
+ac-project
+  PROJID
+  
+  GetProject(projId)
+  LoadProjectFromAsset(projId)
+  
+ac-blueprints
+  BPTEXTMAP -- [bpName, [Bndls]]
+
+  GetBlueprint(projId, bpName)
+  GetBlueprintBndl(projId, bpName)
+  
+  SetBlueprints(projId, blueprints)
+  InjectBluepritn(projId, blueprintDef)
+  UpdateBlueprint(projId, bpName, scriptText)
+  DeleteBlueprint(projId, bpName)
+  
+ac-instances
+  INSTANCES
+
+  GetInstances(projId)
+  GetInstance(projId, instanceId)
+  GetInstanceIdList(projId, currentInstances)
+  GetInstanceUID
+  EditInstance(projId, instanceId)
+  UpdateCurrentInstance(projId, instance)
+  SetInstances(projId, instances)
+  WriteInstances(projId, instances)
+  AddInstance(projId, instance)
+  WriteInstance(projId, instance)
+  DeleteInstance(projId, instanceId)
+  DeleteInstancesByBpname(projId, bpName)
+  RenameInstanceBlueprint(projId, oldBpName, newBpName)
+
+dc-sim-resources
+  BLUEPRINTS -- bpBndls

--- a/gs_packages/gem-srv/package.json
+++ b/gs_packages/gem-srv/package.json
@@ -82,6 +82,7 @@
   "dependencies": {
     "@gemstep/ursys": "^0.1.0-alpha.0",
     "@hapi/code": "^8.0.4",
+    "@iarna/toml": "^2.2.5",
     "@material-ui/core": "^4.9.6",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/gs_packages/gem-srv/src/app/help/codex-keywords.yaml
+++ b/gs_packages/gem-srv/src/app/help/codex-keywords.yaml
@@ -99,7 +99,8 @@ every:
   glossary: >
     xxx
 
-_comment:
+# _comment:
+//:
   info: 'Comment lines help describe the code.'
   glossary: ''
 

--- a/gs_packages/gem-srv/src/app/help/codex-keywords.yaml
+++ b/gs_packages/gem-srv/src/app/help/codex-keywords.yaml
@@ -100,7 +100,7 @@ every:
     xxx
 
 _comment:
-  info: 'Comment lines help describe the code. They are not yet editable except in code view.'
+  info: 'Comment lines help describe the code.'
   glossary: ''
 
 _directive:

--- a/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/ScriptEditor.jsx
@@ -35,6 +35,7 @@
                 EditSymbol_Block
                 or
                 ObjRefSelector_Block
+            SlotEditor_CommentBlock
 
       Script Selector View
 
@@ -65,6 +66,7 @@ import * as WIZCORE from 'modules/appcore/ac-wizcore';
 import * as SLOTCORE from 'modules/appcore/ac-slotcore';
 import * as TRANSPILER from 'script/transpiler-v2';
 import * as SIMDATA from 'modules/datacore/dc-sim-data';
+import * as CHELPER from 'script/tools/comment-utilities';
 
 /// PANELS ////////////////////////////////////////////////////////////////////
 // import PanelSimViewer from './components/PanelSimViewer';
@@ -269,6 +271,7 @@ class ScriptEditor extends React.Component {
     if (this.state.isReady) return; // already initialized
     const { projId } = this.state;
     this.RequestBpEditList(projId);
+    this.RequestPreferences();
     UR.RaiseMessage('INIT_RENDERER'); // Tell PanelSimViewer to request boundaries
     this.setState({ isReady: true });
   }
@@ -300,6 +303,20 @@ class ScriptEditor extends React.Component {
       parms: [projId]
     }).then(rdata => {
       return this.UpdateBpEditList(rdata.result);
+    });
+  }
+
+  /**
+   * This requests preferences data from project-server used to populate
+   * the list of comment styles.
+   */
+  RequestPreferences() {
+    const fnName = 'RequestPreferences';
+    UR.CallMessage('NET:REQ_PROJDATA', {
+      fnName,
+      parms: []
+    }).then(rdata => {
+      rdata.result.forEach(r => CHELPER.AddStyle(r));
     });
   }
 

--- a/gs_packages/gem-srv/src/app/pages/components/InstanceEditorOrig.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/InstanceEditorOrig.jsx
@@ -1,0 +1,591 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+DEPRECATED 6/23/22
+
+This was the original InstanceEditor that relied on keyword
+components (like prop.tsx) being able to generate jsx.
+
+
+
+---
+
+
+InstanceEditor
+
+Shows instance init scripts.
+* Used to define instances in a map.
+* Allows properties to be edited.
+
+Limitations
+* This really does not support nested script editing.
+  Instance initScripts are supposed relativelys imple property setting.
+  If more complex script editing is neeeded, this should probably use
+  SubpanelScript.
+
+props
+* label -- a temporary label for displaying in list mode
+           so we don't have to load/pass the full instance object
+           when clicked and placed in edit mode, the label is properly
+           read from a full instance state object.
+
+props.instance = instance specification: {name, blueprint, initScript}
+  e.g. {name: "fish01", blueprint: "Fish", initScript: "prop x setTo -220↵prop y setTo -220"}
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import React from 'react';
+import clsx from 'clsx';
+import UR from '@gemstep/ursys/client';
+import DeleteIcon from '@material-ui/icons/Delete';
+import VisibilityIcon from '@material-ui/icons/VisibilityOff';
+import { Button, ClickAwayListener } from '@material-ui/core';
+import { GetAllFeatures } from 'modules/datacore/dc-sim-data';
+import * as ACBlueprints from 'modules/appcore/ac-blueprints';
+import * as ACInstances from 'modules/appcore/ac-instances';
+import * as TRANSPILER from 'script/transpiler-v2';
+import { UpdateScript } from 'modules/sim/script/tools/script-to-jsx';
+import { withStyles } from '@material-ui/core/styles';
+import { useStylesHOC } from '../helpers/page-xui-styles';
+import InputField from './InputField';
+
+/// CONSTANTS AND DECLARATIONS ////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('InstEditor');
+const DBG = false;
+
+/// CLASS DEFINITION //////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class InstanceEditor extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      instance: {},
+      isEditable: false,
+      isHovered: false,
+      isSelected: false,
+      isAddingProperty: false,
+      isDeletingProperty: false,
+      ignoreNextClickAway: false
+    };
+    this.GetInstanceName = this.GetInstanceName.bind(this);
+    this.HandleScriptUpdate = this.HandleScriptUpdate.bind(this);
+    this.HandleScriptLineDelete = this.HandleScriptLineDelete.bind(this);
+    this.OnInstanceClick = this.OnInstanceClick.bind(this);
+    this.GetSettableProperties = this.GetAddableProperties.bind(this);
+    this.OnAddProperty = this.OnAddProperty.bind(this);
+    this.OnEnableDeleteProperty = this.OnEnableDeleteProperty.bind(this);
+    this.OnPropMenuSelect = this.OnPropMenuSelect.bind(this);
+    this.OnDeleteInstance = this.OnDeleteInstance.bind(this);
+    this.DoDeselect = this.DoDeselect.bind(this);
+    this.HandleEditEnable = this.HandleEditEnable.bind(this);
+    this.HandleEditDisable = this.HandleEditDisable.bind(this);
+    this.HandleHoverOver = this.HandleHoverOver.bind(this);
+    this.HandleHoverOut = this.HandleHoverOut.bind(this);
+    this.HandleDeselect = this.HandleDeselect.bind(this);
+    this.OnHoverOver = this.OnHoverOver.bind(this);
+    this.OnHoverOut = this.OnHoverOut.bind(this);
+    this.OnNameChange = this.OnNameChange.bind(this);
+    this.OnInstanceSave = this.OnInstanceSave.bind(this);
+    this.OnClickAway = this.OnClickAway.bind(this);
+    this.urStateUpdated = this.urStateUpdated.bind(this);
+    UR.HandleMessage('SCRIPT_UI_CHANGED', this.HandleScriptUpdate);
+    UR.HandleMessage('SCRIPT_LINE_DELETE', this.HandleScriptLineDelete);
+    UR.HandleMessage('INSTANCE_EDIT_ENABLE', this.HandleEditEnable);
+    UR.HandleMessage('INSTANCE_EDIT_DISABLE', this.HandleEditDisable);
+    UR.HandleMessage('SIM_INSTANCE_HOVEROVER', this.HandleHoverOver);
+    UR.HandleMessage('SIM_INSTANCE_HOVEROUT', this.HandleHoverOut);
+    UR.HandleMessage('NET:INSTANCE_DESELECT', this.HandleDeselect);
+  }
+
+  componentDidMount() {
+    const { id } = this.props;
+    const { currentInstance } = UR.ReadFlatStateGroups('instances');
+    if (currentInstance && currentInstance.id === id) {
+      this.setState({ instance: currentInstance });
+    }
+    UR.SubscribeState('instances', this.urStateUpdated);
+  }
+
+  componentWillUnmount() {
+    UR.UnsubscribeState('instances', this.urStateUpdated);
+    UR.UnhandleMessage('SCRIPT_UI_CHANGED', this.HandleScriptUpdate);
+    UR.UnhandleMessage('SCRIPT_LINE_DELETE', this.HandleScriptLineDelete);
+    UR.UnhandleMessage('INSTANCE_EDIT_ENABLE', this.HandleEditEnable);
+    UR.UnhandleMessage('INSTANCE_EDIT_DISABLE', this.HandleEditDisable);
+    UR.UnhandleMessage('SIM_INSTANCE_HOVEROVER', this.HandleHoverOver);
+    UR.UnhandleMessage('SIM_INSTANCE_HOVEROUT', this.HandleHoverOut);
+    UR.UnhandleMessage('NET:INSTANCE_DESELECT', this.HandleDeselect);
+  }
+
+  GetInstanceName() {
+    const { instance } = this.props;
+    return instance && instance.label ? instance.label : 'not loaded';
+  }
+
+  /**
+   * URSYS Script update sent from prop.tsx
+   * @param {*} data
+   */
+  HandleScriptUpdate(data) {
+    const { isEditable } = this.state;
+    if (isEditable) {
+      if (data.exitEdit) {
+        this.DoDeselect();
+      }
+      this.setState(
+        state => {
+          const { instance } = state;
+          instance.initScript = UpdateScript(instance.initScript, data);
+          return { instance };
+        },
+        () => this.OnInstanceSave()
+      );
+    }
+  }
+
+  HandleScriptLineDelete(data) {
+    // Update the script
+    const { isEditable } = this.state;
+    if (isEditable) {
+      this.setState(
+        state => {
+          const { instance } = state;
+          // 1. Convert init script text to array
+          const scriptTextLines = instance.initScript.split('\n');
+          // 2. Remove the line
+          scriptTextLines.splice(data.index, 1);
+          // 3. Convert the script array back to script text
+          const updatedScript = scriptTextLines.join('\n');
+          instance.initScript = updatedScript;
+          return { instance };
+        },
+        () => this.OnInstanceSave()
+      );
+    }
+  }
+
+  /**
+   * User clicked on instance in "Map Instances" panel, wants to edit
+   * @param {*} e
+   */
+  OnInstanceClick(e) {
+    // Ignore clicks when editing. ClickAwayListener will handle closing.
+    const { isEditable } = this.state;
+    if (isEditable) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    // just pass it up to Main (Map Editor) so it's centralized
+    const { id } = this.props;
+    UR.RaiseMessage('SIM_INSTANCE_CLICK', { agentId: id });
+  }
+
+  /// For adding new properties selection menu
+  GetAddableProperties() {
+    const { instance } = this.state;
+    if (!instance) return [];
+    // properties = [...{name, type, defaultvalue, isFeatProp }]
+    let properties = ACBlueprints.GetBlueprintProperties(instance.bpid);
+    // Remove properties that have already been set
+    // 1. Get the list or properties
+    const scriptUnits = TRANSPILER.TextToScript(instance.initScript);
+    const initProperties = scriptUnits.map(unit => {
+      if (
+        unit[0] &&
+        (unit[0].identifier === 'prop' || unit[0].identifier === 'featProp')
+      ) {
+        return unit[1].identifier;
+      }
+      return undefined;
+    });
+    // 2. Remove already set properties
+    properties = properties.filter(p => !initProperties.includes(p.name));
+    return properties;
+  }
+
+  OnAddProperty(e) {
+    e.preventDefault(); // prevent click from deselecting instance
+    e.stopPropagation();
+    this.setState(state => ({
+      isAddingProperty: !state.isAddingProperty
+    }));
+  }
+
+  OnEnableDeleteProperty(e) {
+    e.preventDefault(); // prevent click from deselecting instance
+    e.stopPropagation();
+    // enable deletion
+    this.setState(state => ({
+      isDeletingProperty: !state.isDeletingProperty
+    }));
+  }
+
+  StopEvent(e) {
+    e.preventDefault(); // prevent click from deselecting instance
+    e.stopPropagation();
+  }
+
+  StopPropagation(e) {
+    e.stopPropagation(); // prevent click from deselecting instance
+  }
+
+  OnPropMenuSelect(e) {
+    e.preventDefault(); // prevent click from deselecting instance
+    e.stopPropagation();
+    const selectedProp = e.target.value;
+    if (selectedProp === '') return; // selected the help instructions
+
+    this.setState(
+      state => {
+        const { instance } = state;
+        const addableProperties = this.GetAddableProperties();
+        const property = addableProperties.find(p => p.name === selectedProp);
+        const keyword = property.isFeatProp ? 'featProp' : 'prop';
+        const newScriptLine = `${keyword} ${property.name} setTo ${property.defaultValue}`;
+
+        // 1. Convert init script text to array
+        const scriptTextLines = instance.initScript
+          ? instance.initScript.split('\n')
+          : [];
+        // 2. Add the updated line in the script array
+        scriptTextLines.push(newScriptLine);
+        // 4. Convert the script array back to script text
+        const updatedScript = scriptTextLines.join('\n');
+
+        instance.initScript = updatedScript;
+        return { instance, isAddingProperty: false };
+      },
+      () => this.OnInstanceSave()
+    );
+  }
+
+  OnDeleteInstance(e) {
+    const { instance } = this.state;
+    const { id } = this.props;
+    e.preventDefault();
+    e.stopPropagation();
+    const bpid = instance.bpid;
+    // Tell project-server to remove agent from stage
+    UR.RaiseMessage('LOCAL:INSTANCE_DELETE', { bpid, id });
+  }
+
+  DoDeselect() {
+    const { id } = this.props;
+    let { isSelected, isEditable } = this.state;
+    isEditable = false;
+    isSelected = false;
+    this.setState({ isEditable, isSelected });
+    // And also deselect
+    UR.RaiseMessage('NET:INSTANCE_DESELECT', { agentId: id });
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// URSYS Events
+  ///
+  /**
+   * Enables or disables editing based on 'data' passed
+   * @param {object} data { agentId }
+   */
+  HandleEditEnable(data) {
+    const { id } = this.props;
+    // Is this message for us?
+    if (data.agentId === id) {
+      // YES!  Enable!
+      ACInstances.EditInstance(id);
+      this.setState({
+        isEditable: true,
+        isSelected: true,
+        ignoreNextClickAway: data.source === 'stage'
+      });
+      this.instance.scrollIntoView();
+    } else {
+      // always disable if message is not for us!
+      this.DoDeselect();
+    }
+  }
+  HandleEditDisable(data) {
+    const { id } = this.props;
+    // Is this message for us?
+    if (data.agentId === id) {
+      // YES!  Disable!
+      this.DoDeselect();
+    }
+  }
+  HandleHoverOver(data) {
+    const { isEditable } = this.state;
+    const { id } = this.props;
+    // Changing the hover state here while the Instance is being
+    // edited results in the whole instance being redrawn
+    // leading to a loss of focus.
+    // So we only set hover if we're not editing?
+    if (data.agentId === id && !isEditable) {
+      this.setState({ isHovered: true });
+    }
+  }
+  HandleHoverOut(data) {
+    const { isEditable } = this.state;
+    const { id } = this.props;
+    // Changing the hover state here while the Instance is being
+    // edited results in the whole instance being redrawn
+    // leading to a loss of focus.
+    // So we only set hoverout if we're not editing?
+    if (data.agentId === id && !isEditable) {
+      this.setState({ isHovered: false });
+    }
+  }
+  HandleDeselect(data) {
+    const { id } = this.props;
+    if (data.agentId === id) {
+      this.setState({
+        isEditable: false,
+        isSelected: false,
+        isHovered: false,
+        isAddingProperty: false
+      });
+    }
+  }
+  OnNameChange(data) {
+    const { isEditable } = this.state;
+    if (isEditable) {
+      if (data.exitEdit) {
+        // Handle "ENTER" being used to exit
+        this.DoDeselect();
+      }
+      this.setState(
+        state => {
+          const { instance } = state;
+          instance.label = data.value !== undefined ? data.value : instance.label;
+          return { instance };
+        },
+        () => this.OnInstanceSave()
+      );
+    }
+  }
+
+  OnInstanceSave() {
+    const { instance } = this.state;
+    UR.WriteState('instances', 'currentInstance', instance);
+  }
+
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Local Events (on InstanceEditor container)
+  ///
+  OnHoverOver() {
+    const { id } = this.props;
+    UR.RaiseMessage('SIM_INSTANCE_HOVEROVER', { agentId: id });
+  }
+  OnHoverOut() {
+    const { id } = this.props;
+    UR.RaiseMessage('SIM_INSTANCE_HOVEROUT', { agentId: id });
+  }
+  OnClickAway(e) {
+    const { id } = this.props;
+    const { isEditable, ignoreNextClickAway } = this.state;
+    if (ignoreNextClickAway) {
+      // Requests to edit via clicking on the instance in the stage
+      // (as opposed to the PanelMapInstances list) will trigger the
+      // ClickAwayListener because the InstanceEditor is enabled and
+      // rendered while the click from draggable bubbles its way
+      // up triggering the ClickAwayListener.  We check for that in
+      // HandleEditEnable and set the ignoreNextClickAway flag.
+      // Stopping propagation at dragEnd doesn't work because it's the wrong
+      // event and ClickAwayListener would trigger anyway.
+      this.setState({ ignoreNextClickAway: false });
+      return;
+    }
+    if (isEditable) this.DoDeselect(); // only deselect if already editing
+  }
+  urStateUpdated(stateObj, cb) {
+    const { id } = this.props;
+    const { currentInstance } = stateObj;
+    if (currentInstance && currentInstance.id === id) {
+      this.setState({ instance: currentInstance });
+    }
+    if (typeof cb === 'function') cb();
+  }
+
+  render() {
+    const {
+      instance,
+      isEditable,
+      isHovered,
+      isSelected,
+      isAddingProperty,
+      isDeletingProperty
+    } = this.state;
+    const { id, label, classes } = this.props;
+
+    if (DBG) console.log(...PR('render', id, instance));
+
+    // if 'instance' data has been loaded (we're editing) then use that
+    // otherwise, use the label passed by PanelMapInstances
+    const inputLabel = (instance && instance.label) || label;
+
+    if (!inputLabel) return 'not loaded yet';
+
+    const addableProperties = this.GetAddableProperties();
+
+    let scriptJSX = '';
+    if (instance) {
+      const source = TRANSPILER.TextToScript(instance.initScript);
+
+      // initScripts really should not be defining new props
+      // (leads to 'prop already added' errors)
+      // but this code is ready for it
+      const initPropMap = TRANSPILER.ExtractBlueprintPropertiesMap(
+        instance.initScript
+      );
+      const blueprintName = instance.bpid;
+      const propMap = new Map([
+        ...ACBlueprints.GetBlueprintPropertiesMap(blueprintName),
+        ...initPropMap
+      ]);
+
+      // MOVE this to ACBlueprint?
+      // Construct list of featProps for script UI menu
+      // This is complicated.
+      // In order to get a list of feature properties, we have to
+      // get the featProps from existing features
+      // AND compile initscript to retrieve any features added there.
+      // And then combine the two featPropMaps.
+
+      // 1. Get featPropMap from current features
+      const features = GetAllFeatures();
+      const featNames = [...features.keys()];
+      const bpFeatPropMap = TRANSPILER.ExtractFeatPropMap(featNames);
+
+      // 2. Get featPropMap from initScript
+      const initFeatPropMap = TRANSPILER.ExtractFeatPropMapFromScript(
+        instance.initScript
+      );
+
+      // 3. Combine the two maps
+      //    We can do this because initScript should not be defining
+      //    new features, so the two sets of feature keys are unique.
+      const featPropMap = new Map([...bpFeatPropMap], [initFeatPropMap]);
+
+      // ORIG
+      // This is dependent on the v1 prop.tsx implementation
+      // that is able to generate jsx
+      //
+      // scriptJSX = TRANSPILER.ScriptToJSX(source, {
+      //   isEditable,
+      //   isDeletable: isDeletingProperty,
+      //   isInstanceEditor: true,
+      //   propMap,
+      //   featPropMap,
+      //   classes
+      // });
+
+      scriptJSX = instance.initScript;
+    }
+
+    let propMenuJSX = '';
+    if (isAddingProperty) {
+      propMenuJSX = (
+        <select
+          onChange={this.OnPropMenuSelect}
+          onClick={this.StopEvent}
+          onPointerDown={this.StopPropagation}
+        >
+          <option value="">-- Select a property... --</option>
+          {addableProperties.map(p => (
+            <option value={p.name} key={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    const disableAddProperties = this.GetAddableProperties().length < 1;
+
+    const inputJSX = (
+      <InputField
+        propName="Name"
+        value={inputLabel}
+        type="string"
+        isEditable={isEditable}
+        onChange={this.OnNameChange}
+      />
+    );
+
+    return (
+      <div
+        ref={c => {
+          this.instance = c;
+        }}
+        className={clsx(classes.instanceSpec, {
+          [classes.instanceSpecHovered]: isHovered,
+          [classes.instanceSpecSelected]: isSelected
+        })}
+        onPointerEnter={this.OnHoverOver}
+        onPointerLeave={this.OnHoverOut}
+        onClick={this.OnInstanceClick}
+      >
+        {!isEditable ? (
+          inputJSX
+        ) : (
+          <ClickAwayListener onClickAway={this.OnClickAway}>
+            <div>
+              <div
+                className={classes.instanceEditorLineItem}
+                style={{ margin: '0.5em 0' }}
+              >
+                <div
+                  className={classes.instanceEditorLabel}
+                  style={{ fontSize: '10px' }}
+                >
+                  Character Type:
+                </div>
+                <div className={classes.instanceEditorData}>{instance.bpid}</div>
+              </div>
+              {inputJSX}
+              <div>{scriptJSX}</div>
+              <br />
+              {isAddingProperty && isEditable && propMenuJSX}
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <button
+                  onClick={this.OnAddProperty}
+                  onPointerDown={this.StopEvent}
+                  type="button"
+                  className={classes.buttonSmall}
+                  title="Add Property"
+                  disabled={disableAddProperties}
+                >
+                  {isAddingProperty ? 'HIDE PROPERTY MENU' : 'SHOW PROPERTY'}
+                </button>
+                {!isAddingProperty && (
+                  <button
+                    onClick={this.OnEnableDeleteProperty}
+                    onPointerDown={this.StopEvent}
+                    type="button"
+                    className={classes.buttonSmall}
+                    title="Delete Property"
+                    style={{}}
+                  >
+                    <VisibilityIcon fontSize="small" />
+                  </button>
+                )}
+              </div>
+              <div style={{ textAlign: 'center', marginTop: '1em' }}>
+                <Button
+                  type="button"
+                  className={classes.buttonLink}
+                  onClick={this.OnDeleteInstance}
+                  startIcon={<DeleteIcon fontSize="small" />}
+                >
+                  DELETE CHARACTER
+                </Button>
+              </div>
+            </div>
+          </ClickAwayListener>
+        )}
+      </div>
+    );
+  }
+}
+
+export default withStyles(useStylesHOC)(InstanceEditor);

--- a/gs_packages/gem-srv/src/app/pages/components/PanelSimulationOrig.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelSimulationOrig.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import UR from '@gemstep/ursys/client';
+
+/// APP MAIN ENTRY POINT //////////////////////////////////////////////////////
+import * as ASSETS from 'modules/asset_core';
+import * as RENDERER from 'modules/render/api-render';
+import { withStyles } from '@material-ui/core/styles';
+import { useStylesHOC } from '../helpers/page-xui-styles';
+import { GS_ASSETS_PROJECT_ROOT } from '../../../../config/gem-settings';
+
+import PanelChrome from './PanelChrome';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('PanelSimulation');
+const DBG = false;
+
+/// URSYS SYSHOOKS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/* @BEN are you inadvertently loading assets twice? The asset load should
+   have been handled by the asset manager automatically */
+UR.HookPhase(
+  'UR/LOAD_ASSETS',
+  () =>
+    new Promise((resolve, reject) => {
+      if (DBG) console.log(...PR('LOADING ASSET MANIFEST @ UR/LOAD_ASSETS...'));
+      void (async () => {
+        if (DBG) console.log(...PR('ASSETS LOADED'));
+        await ASSETS.PromiseLoadAssets(GS_ASSETS_PROJECT_ROOT);
+        resolve();
+      })();
+    })
+);
+
+class PanelSimulation extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      title: 'Virtual Stage'
+    };
+    this.setBoundary = this.setBoundary.bind(this);
+  }
+
+  componentDidMount() {
+    // initialize renderer
+    const renderRoot = document.getElementById('root-renderer');
+    RENDERER.SetGlobalConfig({ actable: true });
+    RENDERER.Init(renderRoot);
+    RENDERER.HookResize(window);
+    window.addEventListener('resize', this.setBoundary);
+  }
+
+  componentWillUnmount() {}
+
+  setBoundary() {
+    const { width, height, bgcolor } = this.props;
+    RENDERER.SetBoundary(width, height, bgcolor);
+  }
+
+  render() {
+    const { title } = this.state;
+    const { id, width, height, bgcolor, isActive, onClick, classes } = this.props;
+
+    return (
+      <PanelChrome id={id} title={title} isActive={isActive} onClick={onClick}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            flexWrap: 'wrap',
+            fontSize: '12px',
+            height: '100%'
+          }}
+        >
+          <div id="root-renderer" style={{ height: '100%' }}>
+            Waiting for start...
+          </div>
+        </div>
+      </PanelChrome>
+    );
+  }
+}
+
+export default withStyles(useStylesHOC)(PanelSimulation);

--- a/gs_packages/gem-srv/src/app/pages/components/VideoBackground.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/VideoBackground.jsx
@@ -1,0 +1,306 @@
+import React from 'react';
+import UR from '@gemstep/ursys/client';
+
+/// APP MAIN ENTRY POINT //////////////////////////////////////////////////////
+import { withStyles } from '@material-ui/core/styles';
+import { useStylesHOC } from '../helpers/page-xui-styles';
+import 'lib/css/gem-ui.css';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('VideoBackground');
+const DBG = false;
+
+class VideoBackground extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      title: 'Video Background',
+      scaleX: 1,
+      scaleY: 1,
+      translateX: 0,
+      translateY: 0,
+      rotate: 0,
+      mirrorX: false,
+      mirrorY: false
+    };
+    this.startVideo = this.startVideo.bind(this);
+    this.updateValue = this.updateValue.bind(this);
+  }
+
+  componentDidMount() {
+    this.startVideo();
+  }
+
+  componentWillUnmount() {}
+
+  startVideo() {
+    if (navigator.mediaDevices === undefined) {
+      console.error(
+        'The current document is not loaded securely or the ' +
+          'browser does not support the Media Devices API.'
+      );
+      return;
+    }
+
+    const CAMERA_FRAMES_PER_SECOND = 30;
+    const DESIRED_VIDEOSTREAM_WIDTH = 800; // match pixi 1024;
+    const DESIRED_VIDEOSTREAM_HEIGHT = 400; // 768;
+
+    let cameraStream = null;
+
+    navigator.mediaDevices.ondevicechange = event => {
+      // Monitor for device changes in the event that the the user camera
+      //  was not ready when the page was loaded and it is later plugged in
+      // Note: This gets called twice per device change
+      console.log('User media device change');
+
+      if (!cameraStream || !cameraStream.active) {
+        streamWebcam();
+      }
+    };
+
+    var video = document.querySelector('#videoElement');
+    var transformedVideo = document.querySelector('#transformed-video');
+    var ctx = transformedVideo.getContext('2d');
+
+    // Draw the video element onto the canvas at the desired framerate, applying
+    //  transformations
+    video.addEventListener('play', () => {
+      console.log('Video started');
+
+      const { scaleX, scaleY, translateX, translateY, rotate, mirrorX, mirrorY } =
+        this.state;
+      const loop = () => {
+        console.log('loop', scaleX);
+        if (!video.paused && !video.ended) {
+          const videoHeight = video.videoHeight;
+          const videoWidth = video.videoWidth;
+          const drawHeight = transformedVideo.height;
+          const drawWidth = transformedVideo.width;
+
+          // Black fill the buffer to prevent lingering visual artifacts should
+          //  the user scale the image below the canvas dimensions
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
+          ctx.fillRect(0, 0, drawWidth, drawHeight);
+
+          // Translate to the center of the canvas, so further transforms
+          //  occur about the center
+          ctx.translate(drawWidth / 2, drawHeight / 2);
+
+          // Apply other translations to the image
+          ctx.translate(translateX, translateY);
+          ctx.rotate((rotate * Math.PI) / 180);
+          ctx.scale((mirrorX ? -1 : 1) * scaleX, (mirrorY ? -1 : 1) * scaleY);
+
+          // Draw the frame image and compensate for the origin shift
+          ctx.drawImage(video, -(videoWidth / 2), -(videoHeight / 2));
+
+          setTimeout(loop, 1000 / CAMERA_FRAMES_PER_SECOND);
+        }
+      };
+
+      loop();
+    });
+
+    // const that = this;
+    // video.addEventListener('loadedmetadata', function () {
+    //   console.warn(`Stream size: ${video.videoWidth}x${video.videoHeight}`);
+    //   console.log(
+    //     'transformedVideo',
+    //     transformedVideo.width,
+    //     transformedVideo.height
+    //   );
+    //   // Set an initial scaling to make the video fill the canvas
+    //   const scaleX = transformedVideo.width / video.videoWidth;
+    //   const scaleY = transformedVideo.height / video.videoHeight;
+    //   // that.setState({ scaleX, scaleY });
+    //   // console.warn(`Scaled to ${scaleX}:${scaleY}`);
+    // });
+
+    // Governs the selection of a media devices, the API will attempt to
+    //  satisfy the given constraints
+    const constraints = {
+      video: {
+        width: DESIRED_VIDEOSTREAM_WIDTH,
+        height: DESIRED_VIDEOSTREAM_HEIGHT
+      }
+    };
+
+    let streamStarting = false;
+    const streamWebcam = () => {
+      // Prevent multiple calls from asking for user permission multiple times
+      if (streamStarting) return;
+      streamStarting = true;
+
+      // Search for attached user media devices (cameras, microphones, speakers)
+      //  that meet the constraints passed in, in this case, just a video device
+      if (navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices
+          .getUserMedia(constraints)
+          .then(stream => {
+            cameraStream = stream;
+            // .. with a stream in hand, it can be bound to certain HTML elements
+            //  such as <video> that are valid sinks for the stream
+            video.srcObject = cameraStream;
+          })
+          .catch(error => {
+            // Unfortunately, the errors generated by Chrome and Firefox are
+            //  different :\
+            // See: https://blog.addpipe.com/common-getusermedia-errors/
+            switch (error.name) {
+              case 'NotFoundError':
+              case 'DevicesNotFoundError':
+              case 'OverconstrainedError':
+              case 'ConstraintNotSatisfiedError':
+                console.error('An appropriate web camera could not be found.');
+                break;
+
+              case 'NotReadableError':
+              case 'TrackStartError':
+              case 'AbortError':
+                console.error('The web camera is already in use.');
+                break;
+
+              case 'NotAllowedError':
+              case 'PermissionDeniedError':
+                console.error(
+                  'The user denied permission to access the web ' + 'camera.'
+                );
+                break;
+
+              default:
+                console.error(
+                  `An unexpected error occured: ` +
+                    `${error.name}:${error.message}`
+                );
+            }
+          })
+          .finally(() => (streamStarting = false));
+      }
+    };
+
+    streamWebcam();
+  }
+
+  updateValue(e) {
+    // console.log('e.target', e.target, e.target.value);
+    // this.setState(updatedObj);
+    const id = e.target.id;
+    const val = Number(e.target.value);
+    let key;
+    if (id === 'scalex-slider') key = 'scaleX';
+    const setting = {};
+    setting[key] = val;
+    console.log('setting', setting);
+    this.setState(setting);
+    this.startVideo();
+  }
+
+  render() {
+    const { title, scaleX } = this.state;
+    const { id, width, height, scale, bgcolor, isActive, onClick, classes } =
+      this.props;
+
+    // console.log('render', width, height, scale);
+
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%'
+        }}
+      >
+        <canvas
+          id="transformed-video"
+          width={820 * scale.x}
+          height={420 * scale.y}
+          style={{
+            zIndex: 1,
+            opacity: 0.5
+          }}
+        />
+        <div className="vidcontrollers">
+          <div className="vidcontrol">
+            <span>Scale:</span>
+            <input
+              id="scalex-slider"
+              type="range"
+              min="0.1"
+              max="5"
+              value={scaleX}
+              step="0.1"
+              onInput={this.updateValue}
+            />
+            <input
+              id="scaley-slider"
+              type="range"
+              min="0.1"
+              max="5"
+              value="1"
+              step="0.1"
+              onInput={e => this.updateValue({ scaleY: e.target.value })}
+            />
+            &nbsp; &nbsp;
+          </div>
+
+          <div className="vidcontrol">
+            <span>Translate:</span>
+            <input
+              id="translatex-slider"
+              type="range"
+              min="-500"
+              max="500"
+              value="0"
+              onInput={e => this.updateValue({ translateX: e.target.value })}
+            />
+            <input
+              id="translatey-slider"
+              type="range"
+              min="-500"
+              max="500"
+              value="0"
+              onInput={e => this.updateValue({ translateY: e.target.value })}
+            />
+            &nbsp; &nbsp;
+          </div>
+
+          <div className="vidcontrol">
+            <span>Rotate:</span>
+            <input
+              id="rotate-slider"
+              type="range"
+              min="0"
+              max="360"
+              value="0"
+              onInput={e => this.updateValue({ rotate: e.target.value })}
+            />
+            &nbsp; &nbsp;
+          </div>
+
+          <div className="vidcontrol">
+            <span>Mirror:</span>
+            <input
+              id="mirror-x"
+              type="checkbox"
+              value="false"
+              onInput={e => this.updateValue({ mirrorX: e.target.checked })}
+            />
+            <input
+              id="mirror-y"
+              type="checkbox"
+              value="false"
+              onInput={e => this.updateValue({ mirrorX: e.target.checked })}
+            />
+          </div>
+        </div>
+        <video autoPlay={true} id="videoElement" style={{ display: 'none' }} />
+      </div>
+    );
+  }
+}
+
+export default withStyles(useStylesHOC)(VideoBackground);

--- a/gs_packages/gem-srv/src/app/pages/helpers/mod-panel-script.js
+++ b/gs_packages/gem-srv/src/app/pages/helpers/mod-panel-script.js
@@ -1,5 +1,9 @@
 /*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
+  REVIEW: Is this being used at all?
+
+
+
   Panel Script - Control Module for Panel Script
 
   Handles business logic for PaneScript

--- a/gs_packages/gem-srv/src/app/pages/helpers/project-server.js
+++ b/gs_packages/gem-srv/src/app/pages/helpers/project-server.js
@@ -38,6 +38,7 @@ import * as ACProject from 'modules/appcore/ac-project';
 import * as ACMetadata from 'modules/appcore/ac-metadata';
 import * as ACBlueprints from 'modules/appcore/ac-blueprints';
 import * as ACInstances from 'modules/appcore/ac-instances';
+import * as ACPreferences from 'modules/appcore/ac-preferences';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ReportMemory } from 'modules/render/api-render';
 import { IsRunning, RoundHasBeenStarted } from 'modules/sim/api-sim';
@@ -300,6 +301,14 @@ function RequestBpEditList(projId = CURRENT_PROJECT_ID) {
       'Tried to current GetProject before setting CURRENT_PROJECT_ID'
     );
   return ACBlueprints.GetBpEditList(projId);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** Handle ScriptEditor's request for project settings (commentSTyles)
+ *  Used by REQ_PROJ_DATA
+ * @return [ {matchString, cssClass, color, backgroundColor, help, isBookmarked} ]
+ */
+function RequestPreferences() {
+  return ACPreferences.GetPreferences();
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** API: Used by REQ_PROJ_DATA and Main
@@ -740,6 +749,7 @@ function InstanceHoverOut(data) {
 const FN_LOOKUP = {
   RequestProject,
   RequestBpEditList,
+  RequestPreferences,
   GetProjectBoundary: GetBoundary,
   GetCharControlBpNames,
 

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -12,7 +12,7 @@
 import React from 'react';
 import { UnpackToken, TokenValue } from 'script/tools/script-tokenizer';
 import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
-import * as CHelper from 'script/tools/comment-utilities';
+import * as CHELPER from 'script/tools/comment-utilities';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -336,7 +336,7 @@ export function GToken(props) {
     // if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
     // if (label.includes('🔎')) classes += ' explanationCommentBody';
     // if (label.includes('✏️')) classes += ' changeCommentBody';
-    classes += CHelper.GetClasses(type, label);
+    classes += CHELPER.GetClasses(type, label);
   }
   if (type === 'directive') classes += ' stylePragma';
   if (SPECIAL_IDENTS.includes(label)) classes += ' stylePragma';

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -373,19 +373,20 @@ export function GValidationToken(props) {
   // special types? use additional classes
   if (type === 'identifier' && position === 0) classes += ' styleKey';
   if (type === '{noncode}') {
-    classes += ' styleComment';
-    // Joshua and Morgan added this hack to allow us to style different comments in unique ways
-    // based on their content, so that we can draw attention to certain kinds of ideas
-    // sort of like headers
-    if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
-    if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
-    if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
-    if (label.includes('🔎')) classes += ' explanationCommentBody';
-    if (label.includes('✏️')) classes += ' changeCommentBody';
+    // classes += ' styleComment';
+    // // Joshua and Morgan added this hack to allow us to style different comments in unique ways
+    // // based on their content, so that we can draw attention to certain kinds of ideas
+    // // sort of like headers
+    // if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
+    // if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
+    // if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
+    // if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
+    // if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
+    // if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
+    // if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
+    // if (label.includes('🔎')) classes += ' explanationCommentBody';
+    // if (label.includes('✏️')) classes += ' changeCommentBody';
+    classes += CHELPER.GetClasses(type, label);
   }
   if (type === 'directive') classes += ' stylePragma';
   if (SPECIAL_IDENTS.includes(label)) classes += ' stylePragma';

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -293,6 +293,7 @@ export function GToken(props) {
   const { tokenKey, token, selected, position } = props;
   const [type, value] = UnpackToken(token); // simple values or object
   let label;
+  let cssStyle = {};
   switch (type) {
     case 'identifier':
       label = value;
@@ -324,6 +325,7 @@ export function GToken(props) {
 
   if (type === '{noncode}') {
     classes += CHELPER.GetClasses(type, label);
+    cssStyle = { ...CHELPER.GetCSSStyle(type, label) };
   }
   if (type === 'directive') classes += ' stylePragma';
   if (SPECIAL_IDENTS.includes(label)) classes += ' stylePragma';
@@ -332,7 +334,7 @@ export function GToken(props) {
   if (type) classes += ` ${type}Type`;
   // if not, emit the token element
   return (
-    <div className={classes} data-key={tokenKey}>
+    <div className={classes} data-key={tokenKey} style={cssStyle}>
       {label}
     </div>
   );
@@ -357,10 +359,12 @@ export function GValidationToken(props) {
   let classes = selected
     ? 'gwiz gtoken styleOpen selected'
     : 'gwiz gtoken styleOpen';
+  let cssStyle = {};
   // special types? use additional classes
   if (type === 'identifier' && position === 0) classes += ' styleKey';
   if (type === '{noncode}') {
     classes += CHELPER.GetClasses(type, label);
+    cssStyle = { ...CHELPER.GetCSSStyle(type, label) };
   }
   if (type === 'directive') classes += ' stylePragma';
   if (SPECIAL_IDENTS.includes(label)) classes += ' stylePragma';
@@ -416,7 +420,7 @@ export function GValidationToken(props) {
       <div className="gwiz gslot-ed meta styleHelp">{help}</div> */}
     </>
   ) : (
-    <div className={classes} data-key={tokenKey} title={help}>
+    <div className={classes} data-key={tokenKey} title={help} style={cssStyle}>
       {displayLabel} {help}
     </div>
   );

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -12,6 +12,7 @@
 import React from 'react';
 import { UnpackToken, TokenValue } from 'script/tools/script-tokenizer';
 import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
+import * as CHelper from 'script/tools/comment-utilities';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -322,19 +323,20 @@ export function GToken(props) {
   if (type === 'identifier' && position === 0) classes += ' styleKey';
 
   if (type === '{noncode}') {
-    classes += ' styleComment';
-    // Joshua and Morgan added this hack to allow us to style different comments in unique ways
-    // based on their content, so that we can draw attention to certain kinds of ideas
-    // sort of like headers
-    if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
-    if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
-    if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
-    if (label.includes('🔎')) classes += ' explanationCommentBody';
-    if (label.includes('✏️')) classes += ' changeCommentBody';
+    // classes += ' styleComment';
+    // // Joshua and Morgan added this hack to allow us to style different comments in unique ways
+    // // based on their content, so that we can draw attention to certain kinds of ideas
+    // // sort of like headers
+    // if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
+    // if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
+    // if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
+    // if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
+    // if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
+    // if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
+    // if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
+    // if (label.includes('🔎')) classes += ' explanationCommentBody';
+    // if (label.includes('✏️')) classes += ' changeCommentBody';
+    classes += CHelper.GetClasses(type, label);
   }
   if (type === 'directive') classes += ' stylePragma';
   if (SPECIAL_IDENTS.includes(label)) classes += ' stylePragma';

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -323,19 +323,6 @@ export function GToken(props) {
   if (type === 'identifier' && position === 0) classes += ' styleKey';
 
   if (type === '{noncode}') {
-    // classes += ' styleComment';
-    // // Joshua and Morgan added this hack to allow us to style different comments in unique ways
-    // // based on their content, so that we can draw attention to certain kinds of ideas
-    // // sort of like headers
-    // if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
-    // if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
-    // if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
-    // if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
-    // if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
-    // if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
-    // if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
-    // if (label.includes('🔎')) classes += ' explanationCommentBody';
-    // if (label.includes('✏️')) classes += ' changeCommentBody';
     classes += CHELPER.GetClasses(type, label);
   }
   if (type === 'directive') classes += ' stylePragma';
@@ -373,19 +360,6 @@ export function GValidationToken(props) {
   // special types? use additional classes
   if (type === 'identifier' && position === 0) classes += ' styleKey';
   if (type === '{noncode}') {
-    // classes += ' styleComment';
-    // // Joshua and Morgan added this hack to allow us to style different comments in unique ways
-    // // based on their content, so that we can draw attention to certain kinds of ideas
-    // // sort of like headers
-    // if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
-    // if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
-    // if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
-    // if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
-    // if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
-    // if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
-    // if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
-    // if (label.includes('🔎')) classes += ' explanationCommentBody';
-    // if (label.includes('✏️')) classes += ' changeCommentBody';
     classes += CHELPER.GetClasses(type, label);
   }
   if (type === 'directive') classes += ' stylePragma';

--- a/gs_packages/gem-srv/src/app/pages/wiz/edit/EditSymbol.orig.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/edit/EditSymbol.orig.tsx
@@ -1,0 +1,298 @@
+/* eslint-disable no-inner-declarations */
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  SymbolSelector - A component that accepts selection of
+  { sel_linenum, sel_linepos } and draws out everything in it
+
+  validation data contains all the symbol information for the current
+  vm_pageline, which has validation tokens for each corresponding scriptunit
+
+  prop agent.genergy setmin 0
+  script unit: { identify:prop } { objref:[agent,genergy] } { identifier:setmin } { value:0 }
+  valids unit: { error, unitText, gsType, ...keys of TSymbolData }, ...
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import React from 'react';
+import UR from '@gemstep/ursys/client';
+import * as TRANSPILER from 'script/transpiler-v2';
+import * as CHECK from 'modules/datacore/dc-sim-data-utils';
+import * as WIZCORE from 'modules/appcore/ac-wizcore';
+import { GLabelToken, GSymbolToken, StackUnit } from '../SharedElements';
+import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('SymbolSelector');
+
+const HIDDEN_SYMBOLS = [
+  // keywords
+  'randompos',
+  'dbgtick',
+  'if',
+  'call',
+  '_line',
+  '_pragma',
+  'keyworderr',
+  'stackadd',
+  'stacksub',
+  'stackmul',
+  'stackdiv',
+  'usefeature',
+  // features
+  'global'
+];
+const ADVANCED_SYMBOLS = [
+  // keywords
+  'exprpush',
+  'proppop',
+  'proppush',
+  'featproppop',
+  'featproppush',
+  'dbgout',
+  'dbgstack',
+  'dbgcontext',
+  'dbgerror',
+  // features
+  'cursor'
+];
+
+/// COMPONENT DEFINITION //////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export function EditSymbol(props) {
+  // we need the current selection
+  const { selection = {} } = props;
+  const { sel_linenum, sel_linepos, vmPageLine, sel_slotpos } = selection;
+  const label = `options for token ${sel_linenum}:${sel_linepos}`;
+  let symbolType;
+
+  // Keep track of symbols being used in the original script line,
+  // especially advanced or hidden symbols, so that we can show
+  // them and let the user reselect them.  NOTE that after
+  // saving the slot line, these will no longer appear though.
+  const SYMBOLS_IN_USE = [];
+  if (vmPageLine)
+    vmPageLine.lineScript.forEach(tok => {
+      if (tok.identifier) SYMBOLS_IN_USE.push(tok.identifier.toLowerCase());
+    });
+
+  // this is a managed TextBuffer with name "ScriptContextor"
+
+  const allDicts = [];
+
+  const { slots_validation } = WIZCORE.State(); // TValidatedScriptUnit
+  // test clause
+  if (sel_linenum > 0 && sel_linepos > 0) {
+    // const vdata = WIZCORE.ValidateSelectedLine();
+    // console.log(vdata);
+
+    // ORIG
+    // const vIndex = sel_linepos - 1;
+    // BL: Use slot position instead of lineposition (sel_linepos)
+    //     so that we display the currently selected slot type?
+    if (sel_slotpos < 0) return 'Click on a word above to edit it.'; // clicked ScriptView, not SelectEditorLineSlot
+    const vIndex = CHECK.OffsetLineNum(sel_slotpos, 'sub');
+
+    const { validationTokens } = slots_validation;
+
+    // no more validation tokens
+    if (vIndex >= validationTokens.length) return 'nothing to render';
+
+    const symbolData: TSymbolData = validationTokens[vIndex]; // indx into line
+    /* symbolData has the current symbol data to convert into viewdata
+       `symbolData` looks like this: {
+          features: {Costume: {…}, Physics: {…}, AgentWidgets: {…}}
+          gsType: "objref"
+          props: {x: {…}, y: {…}, statusText: {…}, eType: {…}, energyLevel: {…}, …}
+          unitText: "energyLevel"
+        }
+    */
+    const { unitText, symbolScope, error, gsType, ...dicts } = symbolData;
+    /* `dicts` looks like this: {
+          features: {Costume: {…}, Physics: {…}, AgentWidgets: {…}}
+          props: {x: {…}, y: {…}, statusText: {…}, eType: {…}, energyLevel: {…}, …}
+        }
+    */
+    symbolType = gsType;
+
+    // Don't render choices if the current selection should be an input form
+    if (gsType === 'number' || gsType === 'string' || gsType === 'boolean')
+      return '';
+
+    // See symbol-utilities.DecodeSymbolViewData
+    const viewData = WIZCORE.DecodeSymbolViewData(symbolData); // returns the list of symbolnames for a particular symbol
+    /* TODO: it would be nice to make unitText indicate it's the current value */
+    // VALIDATION TOKENS are stored by key in the dicts
+    // e.g. Keywords, Props, Methods, etc
+    /* `viewData` looks like this at this point: {
+            features: {info: 'Costume, Physics, AgentWidgets', items: ['Costume', 'AgentWidgets', 'Population']}
+            props: {info: 'x, y, statusText, eType, energyLevel, energyUse', items: Array(6)}
+            unitText: "energyLevel"
+        }
+    */
+
+    /**
+     * Renders jsx for each category of symbol and each individual selectable symbol
+     * in a two column grid format.
+     * Used for both the top level `props` and recursive (e.g. `feature.Costume`) props
+     * @param {object} sd - symbolData dicts
+     * @param {object} vd - viewData
+     * @param {string} parentLabel - extra label for features, e.g. "Costume"
+     * @returns jsx
+     */
+    function f_render_choices(sd, vd, parentLabel = '') {
+      const categoryDicts = [];
+      Object.keys(sd).forEach((stype, i) => {
+        const rowKey = `${sel_linenum}:${i}`;
+        // NEW CODE: Look up from viewData specific to the recursive context
+        const vdata = vd[stype];
+        const { info, items } = vdata;
+        // ORIG CODE: Look up from general viewData
+        // const { info, items } = viewData[stype];
+        const choices = []; // this is the list of choices
+        const expertChoices = []; // hack to show expert keywords in a different area
+        // get all the choices for this symbol type
+        items.forEach(choice => {
+          const choiceKey = `${stype}:${choice || GUI_EMPTY_TEXT}`;
+          const tok = (
+            <GSymbolToken
+              key={choiceKey}
+              symbolType={stype}
+              unitText={unitText}
+              choice={choice || GUI_EMPTY_TEXT}
+            />
+          );
+          if (
+            HIDDEN_SYMBOLS.includes(choice.toLowerCase()) &&
+            SYMBOLS_IN_USE.includes(choice.toLowerCase())
+          ) {
+            // 1. If the choice is supposed to be hidden, but
+            //    is currently in use in the original script line,
+            //    show it in the "expert" section so that it
+            //    can be reselected
+            expertChoices.push(tok);
+          } else if (HIDDEN_SYMBOLS.includes(choice.toLowerCase())) {
+            // 2. Hide unsupported and deprecated keywords
+            return;
+          } else if (ADVANCED_SYMBOLS.includes(choice.toLowerCase())) {
+            // 3. Show expert keywords
+            expertChoices.push(tok);
+          } else {
+            // 4. Regular keyword
+            choices.push(tok);
+          }
+        });
+        // push a left-most label with symbolType with all the symbols
+        // this will be displayed in a two-column grid in the render function
+        // so the left will be the same height as the right
+        categoryDicts.push(
+          <div key={rowKey} style={{ display: 'contents' }}>
+            <GLabelToken
+              key={rowKey}
+              name={parentLabel ? `${parentLabel}\n${symbolType}` : symbolType}
+            />
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+              {[...choices]}
+            </div>
+          </div>
+        );
+        if (expertChoices.length > 0) {
+          // Expert
+          categoryDicts.push(
+            <div key={`adv${rowKey}`} style={{ display: 'contents' }}>
+              <GLabelToken
+                key={`adv${rowKey}`}
+                name={
+                  parentLabel
+                    ? `expert ${parentLabel}\n${symbolType}`
+                    : `expert ${symbolType}`
+                }
+                secondary
+              />
+              <div style={{ display: 'flex', flexWrap: 'wrap', opacity: '0.7' }}>
+                {[...expertChoices]}
+              </div>
+            </div>
+          );
+        }
+      });
+      return categoryDicts;
+    }
+
+    // Features need special handling.
+    // By default, symbol-utilities.DecodeSymbolViewData converts features into a shallow
+    // list of Features available in the blueprint, e.g. "Costume", "AgentWidgets".
+    // But what we actually want are a list of the methods and props for each
+    // specific feature, e.g. 'Costume.costumeName'.  So we do some extra processing
+    // to recursively reach into each feature to determine the props and
+    // methods.
+    //
+    // Walk down dicts
+    // 1. if the key is 'features', recursively expand its props and methods.
+    // 2. if the key is plain `props`, just expand it normally
+    Object.entries(dicts).forEach(
+      ([dictName, v]: [keyof TSymbolData, TSymbolData]) => {
+        if (Array.isArray(symbolScope) && !symbolScope.includes(dictName)) return;
+        // console.group('symbolType', k, 'symbolDictionary', v);
+
+        if (Array.isArray(symbolScope) && symbolScope.includes('features')) {
+          // 1. feature, so recursively expand
+          Object.entries(v).forEach(
+            ([featureName, featureDict]: [string, TSymbolData]) => {
+              if (gsType === 'objref') {
+                // prop symbolData
+                const sd: TSymbolData = {};
+                sd.props = featureDict.props;
+                // prop viewData
+                const vd = WIZCORE.DecodeSymbolViewData(featureDict);
+                // render it
+                allDicts.push(f_render_choices(sd, vd, dictName));
+              } else if (gsType === 'method') {
+                // method symbolData
+                const sd: TSymbolData = {};
+                sd.methods = featureDict.methods;
+                // method viewData
+                const vd = WIZCORE.DecodeSymbolViewData(featureDict);
+                // render it
+                allDicts.push(f_render_choices(sd, vd, dictName));
+              } else {
+                // unspported gsType
+              }
+            }
+          );
+        } else {
+          // 2. not a feature, just render the keys
+          const sd = {};
+          sd[dictName] = v;
+          allDicts.push(f_render_choices(sd, viewData, dictName));
+        }
+        // console.groupEnd();
+      }
+    );
+  }
+
+  /// RENDER //////////////////////////////////////////////////////////////////
+  /// drawn as "SCRIPT LINE EDITOR"
+  /// [SYMBOL TYPE] symbol symbol symbol
+  const prompt = `SELECT A ${symbolType}`;
+  return (
+    <StackUnit label={prompt} type="symbol" open sticky>
+      {allDicts.map((row, i) => {
+        const key = `${sel_linenum}.${i}`;
+        return (
+          <div
+            className="gline"
+            key={key}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '100px 1fr',
+              gap: '1px'
+            }}
+          >
+            {row}
+          </div>
+        );
+      })}
+    </StackUnit>
+  );
+}

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
@@ -208,6 +208,7 @@ export function ScriptViewWiz_Block(props) {
         lineJSX = (
           <>
             <button
+              id="LineBtnAddBefore"
               className="outline btnAddBefore"
               onClick={e => EDITMGR.AddLine('before')}
             >
@@ -243,6 +244,22 @@ export function ScriptViewWiz_Block(props) {
   if (DBG) {
     console.groupCollapsed('Wizard DBG');
     console.log(DBGTEXT);
+  }
+
+  // Scroll to the currently selected line if it's not visible
+  // The #LineBtnAddBefore button is a convenient way to find the selected line
+  // it's only present if a line is selected, and it makes use the top "+" line
+  // button is visible as is the line before
+  const LineBtnAddBefore = document.getElementById('LineBtnAddBefore');
+  if (LineBtnAddBefore) {
+    const elTop = LineBtnAddBefore.offsetTop;
+    const elBottom = elTop + LineBtnAddBefore.clientHeight;
+    // the scroll container is actually the PanelChrome, so we grab the parent
+    const container = document.getElementById('ScriptViewScroller').parentElement;
+    const containerTop = container.scrollTop;
+    const containerBottom = containerTop + container.clientHeight;
+    if (containerTop < elTop || containerBottom > elBottom)
+      LineBtnAddBefore.scrollIntoView();
   }
 
   return (

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
@@ -246,22 +246,6 @@ export function ScriptViewWiz_Block(props) {
     console.log(DBGTEXT);
   }
 
-  // Scroll to the currently selected line if it's not visible
-  // The #LineBtnAddBefore button is a convenient way to find the selected line
-  // it's only present if a line is selected, and it makes use the top "+" line
-  // button is visible as is the line before
-  const LineBtnAddBefore = document.getElementById('LineBtnAddBefore');
-  if (LineBtnAddBefore) {
-    const elTop = LineBtnAddBefore.offsetTop;
-    const elBottom = elTop + LineBtnAddBefore.clientHeight;
-    // the scroll container is actually the PanelChrome, so we grab the parent
-    const container = document.getElementById('ScriptViewScroller').parentElement;
-    const containerTop = container.scrollTop;
-    const containerBottom = containerTop + container.clientHeight;
-    if (containerTop < elTop || containerBottom > elBottom)
-      LineBtnAddBefore.scrollIntoView();
-  }
-
   return (
     <>
       <div id="ScriptWizardView" style={sScriptView}>

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptView_Pane.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptView_Pane.jsx
@@ -534,7 +534,7 @@ class ScriptView_Pane extends React.Component {
       >
         <option value={''}>-- select a bookmark --</option>
         {bookmarks.map(b => (
-          <option key={b.lineNum} value={b.lineNum} dataKey={`${b.lineNum}, 0`}>
+          <option key={b.lineNum} value={b.lineNum}>
             {b.lineNum}:&nbsp;{b.comment}
           </option>
         ))}

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -253,8 +253,9 @@ class SlotEditor_Block extends React.Component {
         let label = vtok.gsName;
         let error = 'no error';
         instructionsHelpTxt = 'Enter your comment text (do not use quotes)';
-        let syntaxHelpTxt = 'syntaxHelp';
-        let tokenHelpTxt = 'tokenHelp';
+        let syntaxHelpTxt = 'Comments begin with "//".';
+        let tokenHelpTxt =
+          '[_comment] (displayed as "//") is used to add helpful descriptions of what the code should do.';
         let viewState = 'viewState';
         tokenList.push(
           <GValidationToken
@@ -286,8 +287,10 @@ class SlotEditor_Block extends React.Component {
             name={'string'} // added
             label={commentText} // inside the token box
             error={error}
-            syntaxHelp={syntaxHelpTxt}
-            help={tokenHelpTxt}
+            syntaxHelp={'Strings are used to store letters or numbers'} // clone
+            help={
+              'Enter text that explains what the code does. Optionally, select a comment style to format the comments and/or provide bookmarks.'
+            }
             viewState={'valid'}
             isSlot
             isRightSide={true} // force help popup to right align

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -98,8 +98,9 @@ import * as SLOTCORE from 'modules/appcore/ac-slotcore';
 import * as CHECK from 'modules/datacore/dc-sim-data-utils';
 import * as HELP from 'app/help/codex';
 import { SlotEditorSelect_Block } from './SlotEditorSelect_Block';
+import SlotEditor_CommentBlock from './SlotEditor_CommentBlock';
 import Dialog from '../../../pages/components/Dialog';
-import { GValidationToken, StackUnit, HelpLabel } from '../SharedElements';
+import { GValidationToken, StackUnit } from '../SharedElements';
 import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -125,8 +126,7 @@ class SlotEditor_Block extends React.Component {
     this.CancelSlotEdit = this.CancelSlotEdit.bind(this);
     this.DeleteSlot = this.DeleteSlot.bind(this);
     this.HandleSaveDialogClick = this.HandleSaveDialogClick.bind(this);
-    this.ProcessCommentInput = this.ProcessCommentInput.bind(this);
-    this.HandleCommentKeydown = this.HandleCommentKeydown.bind(this);
+    this.HandleCommentUpdate = this.HandleCommentUpdate.bind(this);
   }
 
   componentDidMount() {
@@ -165,22 +165,12 @@ class SlotEditor_Block extends React.Component {
       if (doSave) this.SaveSlot();
     });
   }
-  /// -- Comment Input Handlers
-  ///    Special handling for comments -- handle input updates
-  ///    directly from the comment input component, and stuff
-  ///    the changed text directly into script line.
-  ProcessCommentInput(event) {
-    event.preventDefault();
+  /// -- Comment Update Handlers -- `onChange` handler for SlotEditor_CommentBlock
+  HandleCommentUpdate(commentText) {
     EDITMGR.UpdateSlot({
-      value: String(event.target.value),
+      value: String(commentText),
       type: 'comment' // script token type is 'comment'
     });
-  }
-  HandleCommentKeydown(event) {
-    if (event.key === 'Enter') {
-      this.ProcessCommentInput(event);
-      event.target.select();
-    }
   }
 
   /// RENDERER ////////////////////////////////////////////////////////////////
@@ -272,7 +262,7 @@ class SlotEditor_Block extends React.Component {
           <GValidationToken
             key={tokenKey}
             tokenKey={tokenKey}
-            position={1}
+            position={2}
             selected={true}
             type={'string'} // over the token box
             name={'string'} // added
@@ -536,29 +526,15 @@ class SlotEditor_Block extends React.Component {
 
     /// choices - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     const choicesjsx = isComment ? (
-      /// -- comment choices
+      /// -- show comment choices script line is a comment
       <div id="SEB_choices" className="gsled choices">
-        <div id="SES_str" className="gsled input">
-          <HelpLabel
-            prompt={'Type in a comment'}
-            info={'Comments are text strings to describe the intent of the code.'}
-            open
-            pad="5px"
-          />
-          <input
-            key={`${sel_linenum},${1}`}
-            defaultValue={commentText}
-            type="text"
-            onChange={this.ProcessCommentInput}
-            onKeyDown={this.HandleCommentKeydown}
-          />
-        </div>
-        <div className="gsled choicesline choiceshelp">
-          SELECTED: Comment text is used to add comments to scripts.
-        </div>
+        <SlotEditor_CommentBlock
+          defaultText={commentText}
+          onChange={this.HandleCommentUpdate}
+        />
       </div>
     ) : (
-      /// -- keyword choices
+      /// -- else show keyword choices
       <div id="SEB_choices" className="gsled choices">
         {selectedError && (
           <div className="gsled choicesline gwiz styleError">{selectedError}</div>

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -141,7 +141,18 @@ class SlotEditor_Block extends React.Component {
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** INCOMING: handle SLOTCORE event updates */
   HandleSlotUpdate(vmStateEvent) {
-    // EASY VERSION REQUIRING CAREFUL WIZCORE CONTROL
+    // A. COMMENT HANDLING
+    //    Update ONLY slots_linescript SLOTCORE updates if user is updating
+    //    comments.  Skip slots_validation updates so that selecting a different
+    //    comment line doesn't overwrite the current SlotEditor_CommentBlock state.
+    const { slots_linescript, slots_validation, slots_need_saving } =
+      vmStateEvent;
+    if (slots_linescript && !slots_validation) {
+      this.setState({ slots_linescript, slots_need_saving });
+      return; // skip other updates
+    }
+    // B. UPDATE ALL SLOTCORE UPDATES
+    //    EASY VERSION REQUIRING CAREFUL WIZCORE CONTROL
     this.setState(vmStateEvent);
     // CAREFUL VERSION
     // const { script_page } = vmStateEvent;
@@ -166,6 +177,7 @@ class SlotEditor_Block extends React.Component {
     });
   }
   /// -- Comment Update Handlers -- `onChange` handler for SlotEditor_CommentBlock
+  ///    Updates `slots_linescript` whenever comment changes
   HandleCommentUpdate(commentText) {
     EDITMGR.UpdateSlot({
       value: String(commentText),

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -150,7 +150,7 @@ class SlotEditor_Block extends React.Component {
     //    comment line doesn't overwrite the current SlotEditor_CommentBlock state.
     const { slots_linescript, slots_validation, slots_need_saving } =
       vmStateEvent;
-    if (slots_linescript && !slots_validation) {
+    if (slots_linescript && !slots_validation && slots_need_saving) {
       this.setState({ slots_linescript, slots_need_saving });
       return; // skip other updates
     }
@@ -245,7 +245,10 @@ class SlotEditor_Block extends React.Component {
       // Inject a comment tokens (and convert vtok to a comment tok) if
       // a. User has added a new "_comment" keyword, or
       // b. User has selected an existing comment line for editing
-      if (vtok.gsName === 'comment' || vtok.unitText === '_comment') {
+
+      // convert '_comment' to '//'
+      // if (vtok.gsName === 'comment' || vtok.unitText === '_comment') {
+      if (vtok.gsName === 'comment' || vtok.unitText === '//') {
         isComment = true;
         // Token 1 = comment keyword token
         let tokenKey = `${sel_linenum},${0}`;
@@ -255,7 +258,7 @@ class SlotEditor_Block extends React.Component {
         instructionsHelpTxt = 'Enter your comment text (do not use quotes)';
         let syntaxHelpTxt = 'Comments begin with "//".';
         let tokenHelpTxt =
-          '[_comment] (displayed as "//") is used to add helpful descriptions of what the code should do.';
+          'Comments ("//") are used to add helpful descriptions of what the code should do.';
         let viewState = 'viewState';
         tokenList.push(
           <GValidationToken
@@ -264,8 +267,8 @@ class SlotEditor_Block extends React.Component {
             position={0}
             selected={false}
             type={keywordTok.gsType} // over the token box
-            name={'//'} // added
-            label={'_comment'} // inside the token box -- match _comment keyword
+            name={'keyword'} // added
+            label={'//'} // inside the token box -- convert '_comment' to '//'
             error={error}
             syntaxHelp={syntaxHelpTxt}
             help={tokenHelpTxt}

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -239,7 +239,13 @@ class SlotEditor_Block extends React.Component {
     /// a. Check if we're a comment
     if (validationTokenCount > 0) {
       const vtok = validationTokens[0];
-      if (slots_linescript[0] && vtok.gsName === 'comment') {
+      // Inject a comment token (and convert vtok to a comment tok) if
+      // a. User has added a new "_comment" keyword, or
+      // b. User has selected an existing comment line for editing
+      if (
+        slots_linescript[0] &&
+        (vtok.gsName === 'comment' || vtok.unitText === '_comment')
+      ) {
         isComment = true;
         // comment keyword token
         let tokenKey = `${sel_linenum},${0}`;
@@ -269,7 +275,7 @@ class SlotEditor_Block extends React.Component {
         );
         // comment text token
         tokenKey = `${sel_linenum},${1}`;
-        commentText = slots_linescript[0].comment; // use linescript to grab text w/o '//'
+        commentText = slots_linescript[0].comment || ''; // use linescript to grab text w/o '//'
         tokenList.push(
           <GValidationToken
             key={tokenKey}
@@ -307,7 +313,6 @@ class SlotEditor_Block extends React.Component {
         const scriptToken = slots_linescript[i];
 
         const vtok = validationTokens[i];
-        console.log('working on scriptToken', scriptToken, 'vtok', vtok);
         if (vtok.gsType === 'block') {
           // 0. Don't show special featCall method blocks (e.g. createAgent)!
           continue;

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -87,6 +87,9 @@
     for the GVar and feature methods, so these are read directly from
     the validation tokens.
 
+    Comment help is hardcoded because the comment tokens are not real
+    keyword tokens.  See render() around line 233.
+
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import React from 'react';
@@ -228,7 +231,7 @@ class SlotEditor_Block extends React.Component {
     const validationTokenCount = validationTokens.length;
     const tokenList = [];
 
-    /// 3.5. Special Comment Handling
+    /// 3.5. Special Comment Handling - - - - - - - - - - - - - - - - - - - - -
     ///      We inject vtokens for rendering and managing comments
     ///      and then rely on the standard GValidationToken rendering to handle
     ///      the rest of the UI.
@@ -236,18 +239,15 @@ class SlotEditor_Block extends React.Component {
     ///      and we are only providing visual overrides.
     let isComment = false;
     let commentText = '';
-    /// a. Check if we're a comment
-    if (validationTokenCount > 0) {
+    /// a. Check the first vtok to see if we're a comment
+    if (slots_linescript[0] && validationTokenCount > 0) {
       const vtok = validationTokens[0];
-      // Inject a comment token (and convert vtok to a comment tok) if
+      // Inject a comment tokens (and convert vtok to a comment tok) if
       // a. User has added a new "_comment" keyword, or
       // b. User has selected an existing comment line for editing
-      if (
-        slots_linescript[0] &&
-        (vtok.gsName === 'comment' || vtok.unitText === '_comment')
-      ) {
+      if (vtok.gsName === 'comment' || vtok.unitText === '_comment') {
         isComment = true;
-        // comment keyword token
+        // Token 1 = comment keyword token
         let tokenKey = `${sel_linenum},${0}`;
         const keywordTok = { gsType: 'keyword', gsName: vtok.gsName };
         let label = vtok.gsName;
@@ -274,7 +274,7 @@ class SlotEditor_Block extends React.Component {
             isRightSide={false} // force help popup to right align
           />
         );
-        // comment text token
+        // Token 2 = comment text token
         tokenKey = `${sel_linenum},${1}`;
         commentText = slots_linescript[0].comment || ''; // use linescript to grab text w/o '//'
         tokenList.push(
@@ -298,11 +298,9 @@ class SlotEditor_Block extends React.Component {
         );
       }
     }
+    /// END 3.5. Comment Handling - - - - - - - - - - - - - - - - - - - - - - -
 
     /// 4. Process each validation token
-    // const { validationTokens } = slots_validation;
-    // const validationTokenCount = validationTokens.length;
-    // const tokenList = [];
     let extraTokenName;
     if (!isComment) {
       for (let i = 0; i < validationTokenCount; i++) {

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -143,7 +143,7 @@ class SlotEditor_Block extends React.Component {
   HandleSlotUpdate(vmStateEvent) {
     // A. COMMENT HANDLING
     //    Update ONLY slots_linescript SLOTCORE updates if user is updating
-    //    comments.  Skip slots_validation updates so that selecting a different
+    //    comments.  Skips slots_validation updates so that selecting a different
     //    comment line doesn't overwrite the current SlotEditor_CommentBlock state.
     const { slots_linescript, slots_validation, slots_need_saving } =
       vmStateEvent;
@@ -239,7 +239,7 @@ class SlotEditor_Block extends React.Component {
     /// a. Check if we're a comment
     if (validationTokenCount > 0) {
       const vtok = validationTokens[0];
-      if (vtok.gsName === 'comment') {
+      if (slots_linescript[0] && vtok.gsName === 'comment') {
         isComment = true;
         // comment keyword token
         let tokenKey = `${sel_linenum},${0}`;

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -47,6 +47,12 @@
       1.  SLOTCORE.UpdateSlotValue handles the inputs directly from SelectEditor.
           ...which updates `slots_linescript`
 
+  COMMENTS
+
+    Technically "comments" are not GEMSCRIPT keywords and are not
+    compiled and processed as "keywords" are.  Instead, the comment
+    editing UI is a purely visual script line editor that emulates
+    vtokens to display the ScriptEditor_Block components (right panel).
 
   HELP
 
@@ -93,7 +99,7 @@ import * as CHECK from 'modules/datacore/dc-sim-data-utils';
 import * as HELP from 'app/help/codex';
 import { SlotEditorSelect_Block } from './SlotEditorSelect_Block';
 import Dialog from '../../../pages/components/Dialog';
-import { GValidationToken, StackUnit } from '../SharedElements';
+import { GValidationToken, StackUnit, HelpLabel } from '../SharedElements';
 import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -119,6 +125,8 @@ class SlotEditor_Block extends React.Component {
     this.CancelSlotEdit = this.CancelSlotEdit.bind(this);
     this.DeleteSlot = this.DeleteSlot.bind(this);
     this.HandleSaveDialogClick = this.HandleSaveDialogClick.bind(this);
+    this.ProcessCommentInput = this.ProcessCommentInput.bind(this);
+    this.HandleCommentKeydown = this.HandleCommentKeydown.bind(this);
   }
 
   componentDidMount() {
@@ -151,11 +159,28 @@ class SlotEditor_Block extends React.Component {
   DeleteSlot() {
     EDITMGR.DeleteSlot();
   }
-  // -- Save Dialog helpers
+  /// -- Save Dialog helpers
   HandleSaveDialogClick(doSave) {
     SLOTCORE.SendState({ slots_save_dialog_is_open: false }, () => {
       if (doSave) this.SaveSlot();
     });
+  }
+  /// -- Comment Input Handlers
+  ///    Special handling for comments -- handle input updates
+  ///    directly from the comment input component, and stuff
+  ///    the changed text directly into script line.
+  ProcessCommentInput(event) {
+    event.preventDefault();
+    EDITMGR.UpdateSlot({
+      value: String(event.target.value),
+      type: 'comment' // script token type is 'comment'
+    });
+  }
+  HandleCommentKeydown(event) {
+    if (event.key === 'Enter') {
+      this.ProcessCommentInput(event);
+      event.target.select();
+    }
   }
 
   /// RENDERER ////////////////////////////////////////////////////////////////
@@ -182,7 +207,7 @@ class SlotEditor_Block extends React.Component {
     const num = String(sel_linenum).padStart(3, '0');
     if (DBG) console.log(...PR('SlotEditor slots_validation', slots_validation));
 
-    /// 2. Nothing selected, render blank line
+    /// 2A. Nothing selected, render blank line
     if (!slots_validation)
       return (
         <div id="SEB_empty" className="gsled panel panelhelp">
@@ -197,152 +222,220 @@ class SlotEditor_Block extends React.Component {
     let selectedChoiceHelpTxt; // help for the selected choice (not slot)
     let featName; // used to track featCall methods
 
-    /// 4. Process each validation token
     const { validationTokens } = slots_validation;
-    const tokenList = [];
     const validationTokenCount = validationTokens.length;
+    const tokenList = [];
+
+    /// 3.5. Special Comment Handling
+    ///      We inject vtokens for rendering and managing comments
+    ///      and then rely on the standard GValidationToken rendering to handle
+    ///      the rest of the UI.
+    ///      This way the syntax and core script data system remains prisitine
+    ///      and we are only providing visual overrides.
+    let isComment = false;
+    let commentText = '';
+    /// a. Check if we're a comment
+    if (validationTokenCount > 0) {
+      const vtok = validationTokens[0];
+      if (vtok.gsName === 'comment') {
+        isComment = true;
+        // comment keyword token
+        let tokenKey = `${sel_linenum},${0}`;
+        const keywordTok = { gsType: 'keyword', gsName: vtok.gsName };
+        let label = vtok.gsName;
+        let error = 'no error';
+        instructionsHelpTxt = 'Enter your comment text (do not use quotes)';
+        let syntaxHelpTxt = 'syntaxHelp';
+        let tokenHelpTxt = 'tokenHelp';
+        let viewState = 'viewState';
+        tokenList.push(
+          <GValidationToken
+            key={tokenKey}
+            tokenKey={tokenKey}
+            position={0}
+            selected={false}
+            type={keywordTok.gsType} // over the token box
+            name={'//'} // added
+            label={'_comment'} // inside the token box -- match _comment keyword
+            error={error}
+            syntaxHelp={syntaxHelpTxt}
+            help={tokenHelpTxt}
+            viewState={'locked'}
+            isSlot
+            isRightSide={false} // force help popup to right align
+          />
+        );
+        // comment text token
+        tokenKey = `${sel_linenum},${1}`;
+        commentText = slots_linescript[0].comment; // use linescript to grab text w/o '//'
+        tokenList.push(
+          <GValidationToken
+            key={tokenKey}
+            tokenKey={tokenKey}
+            position={1}
+            selected={true}
+            type={'string'} // over the token box
+            name={'string'} // added
+            label={commentText} // inside the token box
+            error={error}
+            syntaxHelp={syntaxHelpTxt}
+            help={tokenHelpTxt}
+            viewState={'valid'}
+            isSlot
+            isRightSide={true} // force help popup to right align
+          />
+        );
+      }
+    }
+
+    /// 4. Process each validation token
+    // const { validationTokens } = slots_validation;
+    // const validationTokenCount = validationTokens.length;
+    // const tokenList = [];
     let extraTokenName;
-    for (let i = 0; i < validationTokenCount; i++) {
-      let label;
-      let type;
-      let viewState;
-      let error;
-      const position = CHECK.OffsetLineNum(i, 'add');
-      const tokenKey = `${sel_linenum},${position}`;
-      const isSelected = sel_slotpos === position;
-      const scriptToken = slots_linescript[i];
+    if (!isComment) {
+      for (let i = 0; i < validationTokenCount; i++) {
+        let label;
+        let type;
+        let viewState;
+        let error;
+        const position = CHECK.OffsetLineNum(i, 'add');
+        const tokenKey = `${sel_linenum},${position}`;
+        const isSelected = sel_slotpos === position;
+        const scriptToken = slots_linescript[i];
 
-      const vtok = validationTokens[i];
-      if (vtok.gsType === 'block') {
-        // 0. Don't show special featCall method blocks (e.g. createAgent)!
-        continue;
-      } else if (vtok.error && scriptToken) {
-        // 1. Error with an entered value
-        //    if there's an error in the token, show the current unitText value,
-        //    but fall back to gsType if there's no value
-        label = vtok.unitText || vtok.gsType || label;
-        viewState = vtok.error.code;
-        error = vtok.error.info;
-      } else if (vtok.error) {
-        // 2. Error because no value
-        //    if there is not current value, show the expected gsType, else show syntax label
-        label = vtok.gsType || label;
-        // if the error is vague, use vague, else use empty
-        if (vtok.error.code === 'vague') viewState = 'vague';
-        else viewState = 'empty-editing';
-        error = vtok.error.info;
-      } else {
-        // 3. No error, just show token
-        label = vtok.unitText || GUI_EMPTY_TEXT;
-        viewState = vtok.viewState;
-      }
-      selectedError = isSelected ? error : selectedError;
-
-      // HELP
-      let tokenHelpTxt;
-      let syntaxHelpTxt;
-      // Save off `keyword` and `featName` for processing of subsequent line tokens
-      // HELP needs to know to look up a featMethod instead of regular prop method
-      // To do that, featName needs to be passed to HELP.ForChoice as the parentLabel
-      // To determine featName, peek at keyword.  If it's a featCall, we need to
-      // pull out the feature name to pass on to m_generateTokenHelp
-      if (i === 0) {
-        // is keyword
-        keyword = vtok.unitText;
-        // deref featName
-        if (['featCall', 'featProp'].includes(vtok.unitText)) {
-          const objref_tok =
-            validationTokens.length > 1
-              ? validationTokens[1].unitText.split('.')
-              : [];
-          featName = objref_tok.length > 1 ? objref_tok[1] : objref_tok[0];
+        const vtok = validationTokens[i];
+        console.log('working on scriptToken', scriptToken, 'vtok', vtok);
+        if (vtok.gsType === 'block') {
+          // 0. Don't show special featCall method blocks (e.g. createAgent)!
+          continue;
+        } else if (vtok.error && scriptToken) {
+          // 1. Error with an entered value
+          //    if there's an error in the token, show the current unitText value,
+          //    but fall back to gsType if there's no value
+          label = vtok.unitText || vtok.gsType || label;
+          viewState = vtok.error.code;
+          error = vtok.error.info;
+        } else if (vtok.error) {
+          // 2. Error because no value
+          //    if there is not current value, show the expected gsType, else show syntax label
+          label = vtok.gsType || label;
+          // if the error is vague, use vague, else use empty
+          if (vtok.error.code === 'vague') viewState = 'vague';
+          else viewState = 'empty-editing';
+          error = vtok.error.info;
+        } else {
+          // 3. No error, just show token
+          label = vtok.unitText || GUI_EMPTY_TEXT;
+          viewState = vtok.viewState;
         }
-        if (vtok.unitText === 'when') featName = 'test'; // A 'test' method will call up conditions tests
-      }
+        selectedError = isSelected ? error : selectedError;
 
-      // show help on right side if this token is on the right
-      const isRightSide = i / validationTokenCount >= 0.5;
+        // HELP
+        let tokenHelpTxt;
+        let syntaxHelpTxt;
+        // Save off `keyword` and `featName` for processing of subsequent line tokens
+        // HELP needs to know to look up a featMethod instead of regular prop method
+        // To do that, featName needs to be passed to HELP.ForChoice as the parentLabel
+        // To determine featName, peek at keyword.  If it's a featCall, we need to
+        // pull out the feature name to pass on to m_generateTokenHelp
+        if (i === 0) {
+          // is keyword
+          keyword = vtok.unitText;
+          // deref featName
+          if (['featCall', 'featProp'].includes(vtok.unitText)) {
+            const objref_tok =
+              validationTokens.length > 1
+                ? validationTokens[1].unitText.split('.')
+                : [];
+            featName = objref_tok.length > 1 ? objref_tok[1] : objref_tok[0];
+          }
+          if (vtok.unitText === 'when') featName = 'test'; // A 'test' method will call up conditions tests
+        }
 
-      // NEW SIMPLER HELP  - - - - - - - - - - - - - - - - - -
-      // One of the challenges here is that we need to look at the context
-      // of the whole script line in order to understand what to ask for.
-      // e.g. a "string" can be different things depending on the keyword
-      // and method and the feature and the feature method or feature prop
-      // being referenced on the script line.
-      // -- 0. Set initial values
-      if (i === 0 && vtok.unitText === '') {
-        // BLANK LINE, force keyword
-        vtok.gsName = vtok.gsType = 'keyword';
-        vtok.unitText = undefined;
-      }
-      //    The tokenizer will set unitText to the string "undefined", so we want to convert it to
-      //    an undefined object else "undefined" will be displayed as a value
-      const selectedValue =
-        vtok.unitText === 'undefined' || vtok.unitText === ''
-          ? undefined
-          : vtok.unitText;
-      // -- 1. Get Help Text Objects: gsNameHelp and gsTypeHelp
-      let gsNameHelp;
-      let gsTypeHelp;
-      //    1A. gsTypeHelp
-      gsTypeHelp = HELP.ForChoice(vtok.gsType, selectedValue, featName);
-      if (vtok.gsType === 'method' && selectedValue && keyword !== 'featCall') {
-        // Special handling for GVar and featProp methods
-        // method help is defined in the Symbols declaration for GVars and featProps
-        // so just look that up directly from the validation token rather than relying on the codex
-        gsTypeHelp =
-          vtok.methods && vtok.methods[selectedValue]
-            ? vtok.methods[selectedValue]
-            : gsTypeHelp; // fall back to generic help if not found
-      }
-      //    1B. gsNameHelp
-      gsNameHelp = HELP.ForChoice(vtok.gsName, undefined); // selectedValue = undefined to force type lookup
-      if (
-        ['featCall', 'featProp'].includes(keyword) &&
-        !['string', 'number', 'boolean'].includes(vtok.gsName) &&
-        !['keyword', 'objref', 'method'].includes(vtok.gsType)
-      ) {
-        // Special handler for feature-defined property subtypes
-        // for `featCall` or `featProp` line arguments
-        // This could be:
-        // * a feature prop (e.g. 'movementType')
-        // * a feature prop method arg (e.g. 'movementTypeString')
-        // * a feature method arg (e.g. monitor 'touchType')
-        //
-        // ignore standard GVAR 'string', 'number', 'boolean' -- ForChoice
-        // ignoring the `keyword` -- b/c that should be a keyword lookup
-        // ignore the `objref` -- b/c that is handled by ForChoice
-        // ignore the `method` -- b/c that is handled by ForChoice
-        // is a feature prop arg or feature prop method arg,
-        // or a feature method arg, so we want to use
-        // the featProp lookup.
-        // We have to do this here and not in ForChoice b/c we don't have
-        // access to the keyword and featName
-        // Custom featProp GVAR subtypes can be defined in the feature
-        // e.g. `touchTypes` and `costumeName` so that they provide
-        // specialized help (e.g. enumerate types of touches)
-        gsNameHelp = HELP.ForFeatProp(vtok.gsName, featName); // selectedValue triggers featPropHelp
-        // for featProp method args (GVARs) that have not been subtyped
-        // e.g. plain GVARs, not subtyped like 'touchType'
-        // fall back to standard type
-        //
-        // We're doing all this so that feature-specific prop help
-        // can be stored with codex-features
-      }
-      // -- 2. Map results to help types
-      if (i === 0) keywordHelpTxt = gsTypeHelp.info; // establish keywordHelp if this is the keyword
-      syntaxHelpTxt = gsNameHelp.info || gsTypeHelp.info; // fall back to gsTypeHellp if there's no gsName help
-      tokenHelpTxt =
-        selectedValue === undefined
-          ? gsTypeHelp.input
+        // show help on right side if this token is on the right
+        const isRightSide = i / validationTokenCount >= 0.5;
+
+        // NEW SIMPLER HELP  - - - - - - - - - - - - - - - - - -
+        // One of the challenges here is that we need to look at the context
+        // of the whole script line in order to understand what to ask for.
+        // e.g. a "string" can be different things depending on the keyword
+        // and method and the feature and the feature method or feature prop
+        // being referenced on the script line.
+        // -- 0. Set initial values
+        if (i === 0 && vtok.unitText === '') {
+          // BLANK LINE, force keyword
+          vtok.gsName = vtok.gsType = 'keyword';
+          vtok.unitText = undefined;
+        }
+        //    The tokenizer will set unitText to the string "undefined", so we want to convert it to
+        //    an undefined object else "undefined" will be displayed as a value
+        const selectedValue =
+          vtok.unitText === 'undefined' || vtok.unitText === ''
+            ? undefined
+            : vtok.unitText;
+        // -- 1. Get Help Text Objects: gsNameHelp and gsTypeHelp
+        let gsNameHelp;
+        let gsTypeHelp;
+        //    1A. gsTypeHelp
+        gsTypeHelp = HELP.ForChoice(vtok.gsType, selectedValue, featName);
+        if (vtok.gsType === 'method' && selectedValue && keyword !== 'featCall') {
+          // Special handling for GVar and featProp methods
+          // method help is defined in the Symbols declaration for GVars and featProps
+          // so just look that up directly from the validation token rather than relying on the codex
+          gsTypeHelp =
+            vtok.methods && vtok.methods[selectedValue]
+              ? vtok.methods[selectedValue]
+              : gsTypeHelp; // fall back to generic help if not found
+        }
+        //    1B. gsNameHelp
+        gsNameHelp = HELP.ForChoice(vtok.gsName, undefined); // selectedValue = undefined to force type lookup
+        if (
+          ['featCall', 'featProp'].includes(keyword) &&
+          !['string', 'number', 'boolean'].includes(vtok.gsName) &&
+          !['keyword', 'objref', 'method'].includes(vtok.gsType)
+        ) {
+          // Special handler for feature-defined property subtypes
+          // for `featCall` or `featProp` line arguments
+          // This could be:
+          // * a feature prop (e.g. 'movementType')
+          // * a feature prop method arg (e.g. 'movementTypeString')
+          // * a feature method arg (e.g. monitor 'touchType')
+          //
+          // ignore standard GVAR 'string', 'number', 'boolean' -- ForChoice
+          // ignoring the `keyword` -- b/c that should be a keyword lookup
+          // ignore the `objref` -- b/c that is handled by ForChoice
+          // ignore the `method` -- b/c that is handled by ForChoice
+          // is a feature prop arg or feature prop method arg,
+          // or a feature method arg, so we want to use
+          // the featProp lookup.
+          // We have to do this here and not in ForChoice b/c we don't have
+          // access to the keyword and featName
+          // Custom featProp GVAR subtypes can be defined in the feature
+          // e.g. `touchTypes` and `costumeName` so that they provide
+          // specialized help (e.g. enumerate types of touches)
+          gsNameHelp = HELP.ForFeatProp(vtok.gsName, featName); // selectedValue triggers featPropHelp
+          // for featProp method args (GVARs) that have not been subtyped
+          // e.g. plain GVARs, not subtyped like 'touchType'
+          // fall back to standard type
+          //
+          // We're doing all this so that feature-specific prop help
+          // can be stored with codex-features
+        }
+        // -- 2. Map results to help types
+        if (i === 0) keywordHelpTxt = gsTypeHelp.info; // establish keywordHelp if this is the keyword
+        syntaxHelpTxt = gsNameHelp.info || gsTypeHelp.info; // fall back to gsTypeHellp if there's no gsName help
+        tokenHelpTxt =
+          selectedValue === undefined
             ? gsTypeHelp.input
-            : gsNameHelp.input // if slot is empty, show input instructions
-          : gsTypeHelp.info || gsTypeHelp.input; // fall back to 'input' if no 'info' (keywords only have input defined)
-      if (isSelected) {
-        // establish the instructions and selected choice help IF this curr
-        instructionsHelpTxt = (
-          <>
-            {/* instructions should always be syntax? {gsTypeHelp.input && gsTypeHelp.input !== gsNameHelp.input && (
+              ? gsTypeHelp.input
+              : gsNameHelp.input // if slot is empty, show input instructions
+            : gsTypeHelp.info || gsTypeHelp.input; // fall back to 'input' if no 'info' (keywords only have input defined)
+        if (isSelected) {
+          // establish the instructions and selected choice help IF this curr
+          instructionsHelpTxt = (
+            <>
+              {/* instructions should always be syntax? {gsTypeHelp.input && gsTypeHelp.input !== gsNameHelp.input && (
               <>
                 {gsTypeHelp.input}
                 <br />
@@ -352,34 +445,35 @@ class SlotEditor_Block extends React.Component {
             Fall back on gsTypeHelp if specific syntax help is not availble
             e.g. for 'featCall Movmement queuePostion x y' fall back on using
             'number' instructions for 'x'.  Useful for subtyped gvars. */}
-            {gsNameHelp.input ? gsNameHelp.input : gsTypeHelp.input}
-          </>
+              {gsNameHelp.input ? gsNameHelp.input : gsTypeHelp.input}
+            </>
+          );
+          // only show selectedChoiceHelp if something is selected
+          selectedChoiceHelpTxt = selectedValue ? gsTypeHelp.info : '';
+        }
+
+        // show Delete button if this is the currently selected token
+        if (isSelected && vtok.error && vtok.error.code === 'extra')
+          extraTokenName = vtok.unitText;
+
+        tokenList.push(
+          <GValidationToken
+            key={tokenKey}
+            tokenKey={tokenKey}
+            position={position}
+            selected={isSelected}
+            type={vtok.gsType} // over the token box
+            name={vtok.gsName} // added
+            label={label} // inside the token box
+            error={error}
+            syntaxHelp={syntaxHelpTxt}
+            help={tokenHelpTxt}
+            viewState={viewState}
+            isSlot
+            isRightSide={isRightSide} // force help popup to right align
+          />
         );
-        // only show selectedChoiceHelp if something is selected
-        selectedChoiceHelpTxt = selectedValue ? gsTypeHelp.info : '';
       }
-
-      // show Delete button if this is the currently selected token
-      if (isSelected && vtok.error && vtok.error.code === 'extra')
-        extraTokenName = vtok.unitText;
-
-      tokenList.push(
-        <GValidationToken
-          key={tokenKey}
-          tokenKey={tokenKey}
-          position={position}
-          selected={isSelected}
-          type={vtok.gsType} // over the token box
-          name={vtok.gsName} // added
-          label={label} // inside the token box
-          error={error}
-          syntaxHelp={syntaxHelpTxt}
-          help={tokenHelpTxt}
-          viewState={viewState}
-          isSlot
-          isRightSide={isRightSide} // force help popup to right align
-        />
-      );
     }
 
     /// line edit help - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -441,7 +535,30 @@ class SlotEditor_Block extends React.Component {
     );
 
     /// choices - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    const choicesjsx = (
+    const choicesjsx = isComment ? (
+      /// -- comment choices
+      <div id="SEB_choices" className="gsled choices">
+        <div id="SES_str" className="gsled input">
+          <HelpLabel
+            prompt={'Type in a comment'}
+            info={'Comments are text strings to describe the intent of the code.'}
+            open
+            pad="5px"
+          />
+          <input
+            key={`${sel_linenum},${1}`}
+            defaultValue={commentText}
+            type="text"
+            onChange={this.ProcessCommentInput}
+            onKeyDown={this.HandleCommentKeydown}
+          />
+        </div>
+        <div className="gsled choicesline choiceshelp">
+          SELECTED: Comment text is used to add comments to scripts.
+        </div>
+      </div>
+    ) : (
+      /// -- keyword choices
       <div id="SEB_choices" className="gsled choices">
         {selectedError && (
           <div className="gsled choicesline gwiz styleError">{selectedError}</div>
@@ -461,7 +578,7 @@ class SlotEditor_Block extends React.Component {
     );
 
     /// save dialog - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // -- Save Dialog Display Data
+    /// -- Save Dialog Display Data
     const lineScript = SLOTCORE.State().slots_linescript || {}; // if no line is selected yet
     const selectedLineText = lineScript
       ? WIZCORE.GetLineScriptText(lineScript)

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
@@ -83,7 +83,9 @@ class SlotEditor_CommentBlock extends React.Component {
 
   /// Concatenate prefx + body - - - - - - - - - - - - - - - - - - - -
   m_ConstructCommentText(commentTextPrefix, commentTextBody) {
-    const commentText = `${commentTextPrefix} ${commentTextBody}`;
+    const commentText = commentTextPrefix
+      ? `${commentTextPrefix} ${commentTextBody}`
+      : commentTextBody;
     return commentText;
   }
 

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
@@ -1,0 +1,177 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  SlotEditor_CommentBlock
+
+  Provides a UI for selecting comment styles and inputting comment text.
+  This replaces the `choicesjsx` block for comment editing.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import React from 'react';
+import UR from '@gemstep/ursys/client';
+import * as CHELPER from 'script/tools/comment-utilities';
+import { HelpLabel } from '../SharedElements';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
+const PR = UR.PrefixUtil('SLOTEDITOR_CommentBlock', 'TagApp');
+
+/// ROOT APPLICATION COMPONENT ////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class SlotEditor_CommentBlock extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const commentStyles = [...CHELPER.COMMENTTYPEMAP.keys()];
+    this.state = {
+      commentStyles
+    };
+
+    this.m_DeconstructCommentText = this.m_DeconstructCommentText.bind(this);
+    this.m_ConstructCommentText = this.m_ConstructCommentText.bind(this);
+    this.HandleStyleSelect = this.HandleStyleSelect.bind(this);
+    this.ProcessCommentInput = this.ProcessCommentInput.bind(this);
+    this.HandleCommentKeydown = this.HandleCommentKeydown.bind(this);
+    this.OnChange = this.OnChange.bind(this);
+  }
+
+  /** Deconstruct stored script comment text into components,
+   * splitting out prefix from body, e.g. `🔎 WHAT DOES THIS MODEL DO?` becomes:
+   *   prefix: `🔎 WHAT`
+   *   body: `DOES THIS MODEL DO?`
+   * @param {*} rawcomment
+   * @returns {Object} { commentTextPrefix:string, commentTextBody:string }
+   */
+  m_DeconstructCommentText(rawcomment) {
+    const { commentStyles } = this.state;
+    let commentTextPrefix = '';
+    let commentTextBody = rawcomment;
+    // Find the defined style
+    const style = commentStyles.find(s => String(rawcomment).startsWith(s));
+    if (style) {
+      commentTextPrefix = style;
+      commentTextBody = String(rawcomment).substring(style.length);
+    }
+    // Return the deconstructed pieces
+    return {
+      commentTextPrefix,
+      commentTextBody
+    };
+  }
+
+  /// Concatenate prefx + body - - - - - - - - - - - - - - - - - - - -
+  m_ConstructCommentText(commentTextPrefix, commentTextBody) {
+    const commentText = `${commentTextPrefix}${commentTextBody}`;
+    return commentText;
+  }
+
+  /// Comment Style Selection Handlers - - - - - - - - - - - - - - - - - - - -
+  HandleStyleSelect(event) {
+    event.preventDefault();
+    const { defaultText } = this.props;
+    const { commentTextPrefix, commentTextBody } =
+      this.m_DeconstructCommentText(defaultText);
+    const updatedCommentTextPrefix = event.target.value;
+    this.OnChange(updatedCommentTextPrefix, commentTextBody);
+  }
+
+  /// Comment Input Handlers - - - - - - - - - - - - - - - - - - - - - - - - -
+  /// Special handling for comments -- handle input updates
+  /// directly from the comment input component, and stuff
+  /// the changed text directly into script line.
+  ProcessCommentInput(event) {
+    event.preventDefault();
+    const { defaultText } = this.props;
+    const { commentTextPrefix, commentTextBody } =
+      this.m_DeconstructCommentText(defaultText);
+    const updatedCommentTextBody = event.target.value;
+    this.OnChange(commentTextPrefix, updatedCommentTextBody);
+  }
+  HandleCommentKeydown(event) {
+    if (event.key === 'Enter') {
+      this.ProcessCommentInput(event);
+      event.target.select();
+    }
+  }
+
+  /// Trigger parent Comment onChange Handler - - - - - - - - - - - - - - - - - - - -
+  OnChange(commentTextPrefix, commentTextBody) {
+    const { onChange } = this.props;
+    const commentText = `${commentTextPrefix}${commentTextBody}`;
+    onChange(commentText);
+  }
+
+  /// render - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  render() {
+    const { defaultText } = this.props;
+    const { commentStyles } = this.state;
+    const { commentTextPrefix, commentTextBody } =
+      this.m_DeconstructCommentText(defaultText);
+
+    /// Show comment choices
+    /// There are two types of comment choices to inject into the chooser:
+    /// A. A menu of comment style choices
+    const commentStyleChoicesJsx = (
+      <div
+        style={{
+          margin: '0 10px',
+          padding: '10px 0'
+        }}
+      >
+        <HelpLabel
+          prompt={'A. (OPTIONAL) Select a Comment Style'}
+          info={'Use comment styles to auto-format comment text.'}
+          open
+          pad="5px"
+        />
+        <select value={commentTextPrefix} onChange={this.HandleStyleSelect}>
+          <option key={'cstyle'} value={''}>
+            -- Select a Comment Style --
+          </option>
+          {commentStyles.map((style, i) => {
+            const key = `cstyle${i}`;
+            return (
+              <option key={key} value={style}>
+                {style}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+    );
+    /// B. An input field for the comment text
+    const commentInputJsx = (
+      <>
+        <div id="SES_str" className="gsled input">
+          <HelpLabel
+            prompt={'B. Type in a comment'}
+            info={'Comments are text strings to describe the intent of the code.'}
+            open
+            pad="5px"
+          />
+          <input
+            value={commentTextBody}
+            type="text"
+            onChange={this.ProcessCommentInput}
+            onKeyDown={this.HandleCommentKeydown}
+          />
+        </div>
+        <div className="gsled choicesline choiceshelp">
+          SELECTED: Comment text is used to add comments to scripts.
+        </div>
+      </>
+    );
+
+    return (
+      <>
+        {commentStyleChoicesJsx}
+        {commentInputJsx}
+      </>
+    );
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default SlotEditor_CommentBlock;

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
@@ -148,7 +148,7 @@ class SlotEditor_CommentBlock extends React.Component {
         />
         <select value={commentTextPrefix} onChange={this.HandleStyleSelect}>
           <option key={'cstyle'} value={''}>
-            -- Select a Comment Style --
+            -- no style --
           </option>
           {commentStyles.map((style, i) => {
             const key = `cstyle${i}`;

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_CommentBlock.jsx
@@ -23,9 +23,7 @@ class SlotEditor_CommentBlock extends React.Component {
   constructor(props) {
     super(props);
 
-    const commentStyles = [...CHELPER.COMMENTTYPEMAP.keys()];
     this.state = {
-      commentStyles,
       savedCommentText: '',
       currentCommentText: ''
     };
@@ -65,7 +63,8 @@ class SlotEditor_CommentBlock extends React.Component {
    * @returns {Object} { commentTextPrefix:string, commentTextBody:string }
    */
   m_DeconstructCommentText(rawcomment) {
-    const { commentStyles } = this.state;
+    const COMMENTTYPEMAP = CHELPER.COMMENTTYPEMAP;
+    const commentStyles = [...COMMENTTYPEMAP.keys()];
     let commentTextPrefix = '';
     let commentTextBody = rawcomment;
     // Find the defined style
@@ -128,13 +127,24 @@ class SlotEditor_CommentBlock extends React.Component {
 
   /// render - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   render() {
-    const { commentStyles, currentCommentText } = this.state;
+    const { currentCommentText } = this.state;
     const { commentTextPrefix, commentTextBody } =
       this.m_DeconstructCommentText(currentCommentText);
-
+    const COMMENTTYPEMAP = CHELPER.COMMENTTYPEMAP;
+    const commentStyleOptions = [];
+    COMMENTTYPEMAP.forEach((val, key) => {
+      const optionkey = `cstyle${key}`;
+      commentStyleOptions.push(
+        <option key={optionkey} value={key}>
+          {key}: {val.help}
+          {val.isBookmark ? '🔖' : ''}
+        </option>
+      );
+    });
     /// Show comment choices
     /// There are two types of comment choices to inject into the chooser:
     /// A. A menu of comment style choices
+    const commentStyles = [...COMMENTTYPEMAP.keys()];
     const commentStyleChoicesJsx = (
       <div
         style={{
@@ -152,14 +162,7 @@ class SlotEditor_CommentBlock extends React.Component {
           <option key={'cstyle'} value={''}>
             -- no style --
           </option>
-          {commentStyles.map((style, i) => {
-            const key = `cstyle${i}`;
-            return (
-              <option key={key} value={style}>
-                {style}
-              </option>
-            );
-          })}
+          {commentStyleOptions}
         </select>
       </div>
     );

--- a/gs_packages/gem-srv/src/lib/vendor/pico_1.4.1.min.css
+++ b/gs_packages/gem-srv/src/lib/vendor/pico_1.4.1.min.css
@@ -1,0 +1,2211 @@
+/*!
+ * Pico.css v1.4.1 (https://picocss.com)
+ * Copyright 2019-2021 - Licensed under MIT
+ */
+:root {
+  --font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Ubuntu',
+    'Cantarell', 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --line-height: 1.5;
+  --font-weight: 400;
+  --font-size: 16px;
+  --border-radius: 0.25rem;
+  --border-width: 1px;
+  --outline-width: 3px;
+  --spacing: 1rem;
+  --typography-spacing-vertical: 1.5rem;
+  --block-spacing-vertical: calc(var(--spacing) * 2);
+  --block-spacing-horizontal: var(--spacing);
+  --grid-spacing-vertical: 0;
+  --grid-spacing-horizontal: var(--spacing);
+  --form-element-spacing-vertical: 0.75rem;
+  --form-element-spacing-horizontal: 1rem;
+  --transition: 0.2s ease-in-out;
+}
+@media (min-width: 576px) {
+  :root {
+    --font-size: 17px;
+  }
+}
+@media (min-width: 768px) {
+  :root {
+    --font-size: 18px;
+  }
+}
+@media (min-width: 992px) {
+  :root {
+    --font-size: 19px;
+  }
+}
+@media (min-width: 1200px) {
+  :root {
+    --font-size: 20px;
+  }
+}
+@media (min-width: 576px) {
+  body > footer,
+  body > header,
+  body > main,
+  section {
+    --block-spacing-vertical: calc(var(--spacing) * 2.5);
+  }
+}
+@media (min-width: 768px) {
+  body > footer,
+  body > header,
+  body > main,
+  section {
+    --block-spacing-vertical: calc(var(--spacing) * 3);
+  }
+}
+@media (min-width: 992px) {
+  body > footer,
+  body > header,
+  body > main,
+  section {
+    --block-spacing-vertical: calc(var(--spacing) * 3.5);
+  }
+}
+@media (min-width: 1200px) {
+  body > footer,
+  body > header,
+  body > main,
+  section {
+    --block-spacing-vertical: calc(var(--spacing) * 4);
+  }
+}
+@media (min-width: 576px) {
+  article {
+    --block-spacing-horizontal: calc(var(--spacing) * 1.25);
+  }
+}
+@media (min-width: 768px) {
+  article {
+    --block-spacing-horizontal: calc(var(--spacing) * 1.5);
+  }
+}
+@media (min-width: 992px) {
+  article {
+    --block-spacing-horizontal: calc(var(--spacing) * 1.75);
+  }
+}
+@media (min-width: 1200px) {
+  article {
+    --block-spacing-horizontal: calc(var(--spacing) * 2);
+  }
+}
+a {
+  --text-decoration: none;
+}
+a.contrast,
+a.secondary {
+  --text-decoration: underline;
+}
+small {
+  --font-size: 0.875em;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  --font-weight: 700;
+}
+h1 {
+  --font-size: 2rem;
+  --typography-spacing-vertical: 3rem;
+}
+h2 {
+  --font-size: 1.75rem;
+  --typography-spacing-vertical: 2.625rem;
+}
+h3 {
+  --font-size: 1.5rem;
+  --typography-spacing-vertical: 2.25rem;
+}
+h4 {
+  --font-size: 1.25rem;
+  --typography-spacing-vertical: 1.874rem;
+}
+h5 {
+  --font-size: 1.125rem;
+  --typography-spacing-vertical: 1.6875rem;
+}
+[type='checkbox'],
+[type='radio'] {
+  --border-width: 2px;
+}
+[type='checkbox'][role='switch'] {
+  --border-width: 3px;
+}
+thead td,
+thead th {
+  --border-width: 3px;
+}
+:not(thead) > * > td {
+  --font-size: 0.875em;
+}
+code,
+kbd,
+pre,
+samp {
+  --font-family: 'Menlo', 'Consolas', 'Roboto Mono', 'Ubuntu Monospace',
+    'Noto Mono', 'Oxygen Mono', 'Liberation Mono', monospace, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+}
+kbd {
+  --font-weight: bolder;
+}
+:root:not([data-theme='dark']),
+[data-theme='light'] {
+  color-scheme: light;
+  --background-color: #fff;
+  --color: #415462;
+  --h1-color: #1b2832;
+  --h2-color: #24333e;
+  --h3-color: #2c3d49;
+  --h4-color: #374956;
+  --h5-color: #415462;
+  --h6-color: #4d606d;
+  --muted-color: #73828c;
+  --muted-border-color: #edf0f3;
+  --primary: #1095c1;
+  --primary-hover: #08769b;
+  --primary-focus: rgba(16, 149, 193, 0.125);
+  --primary-inverse: #fff;
+  --secondary: #596b78;
+  --secondary-hover: #415462;
+  --secondary-focus: rgba(89, 107, 120, 0.125);
+  --secondary-inverse: #fff;
+  --contrast: #1b2832;
+  --contrast-hover: #000;
+  --contrast-focus: rgba(89, 107, 120, 0.125);
+  --contrast-inverse: #fff;
+  --mark-background-color: #fff2ca;
+  --mark-color: #543a26;
+  --ins-color: #388e3c;
+  --del-color: #c62828;
+  --blockquote-border-color: var(--muted-border-color);
+  --blockquote-footer-color: var(--muted-color);
+  --button-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  --button-hover-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  --form-element-background-color: transparent;
+  --form-element-border-color: #a2afb9;
+  --form-element-color: var(--color);
+  --form-element-placeholder-color: var(--muted-color);
+  --form-element-active-background-color: transparent;
+  --form-element-active-border-color: var(--primary);
+  --form-element-focus-color: var(--primary-focus);
+  --form-element-disabled-background-color: #d5dce2;
+  --form-element-disabled-border-color: #a2afb9;
+  --form-element-disabled-opacity: 0.5;
+  --form-element-invalid-border-color: #c62828;
+  --form-element-invalid-active-border-color: #b71c1c;
+  --form-element-valid-border-color: #388e3c;
+  --form-element-valid-active-border-color: #2e7d32;
+  --switch-background-color: #bbc6ce;
+  --switch-color: var(--primary-inverse);
+  --switch-checked-background-color: var(--primary);
+  --range-border-color: #d5dce2;
+  --range-active-border-color: #bbc6ce;
+  --range-thumb-border-color: var(--background-color);
+  --range-thumb-color: var(--secondary);
+  --range-thumb-hover-color: var(--secondary-hover);
+  --range-thumb-active-color: var(--primary);
+  --table-border-color: var(--muted-border-color);
+  --table-row-stripped-background-color: #f6f8f9;
+  --code-background-color: #edf0f3;
+  --code-color: var(--muted-color);
+  --code-kbd-background-color: var(--contrast);
+  --code-kbd-color: var(--contrast-inverse);
+  --code-tag-color: #b34d80;
+  --code-property-color: #3d888f;
+  --code-value-color: #998866;
+  --code-comment-color: #a2afb9;
+  --accordion-border-color: var(--muted-border-color);
+  --accordion-close-summary-color: var(--color);
+  --accordion-open-summary-color: var(--muted-color);
+  --card-background-color: var(--background-color);
+  --card-border-color: var(--muted-border-color);
+  --card-box-shadow: 0 0.125rem 1rem rgba(27, 40, 50, 0.04),
+    0 0.125rem 2rem rgba(27, 40, 50, 0.08),
+    0 0 0 0.0625rem rgba(27, 40, 50, 0.024);
+  --card-sectionning-background-color: #fbfbfc;
+  --progress-background-color: #d5dce2;
+  --progress-color: var(--primary);
+  --loading-spinner-opacity: 0.5;
+  --tooltip-background-color: var(--contrast);
+  --tooltip-color: var(--contrast-inverse);
+  --icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(65, 84, 98, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-date: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(65, 84, 98, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='16' y1='2' x2='16' y2='6'%3E%3C/line%3E%3Cline x1='8' y1='2' x2='8' y2='6'%3E%3C/line%3E%3Cline x1='3' y1='10' x2='21' y2='10'%3E%3C/line%3E%3C/svg%3E");
+  --icon-time: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(65, 84, 98, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-search: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(65, 84, 98, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E");
+  --icon-checkbox: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-minus: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='5' y1='12' x2='19' y2='12'%3E%3C/line%3E%3C/svg%3E");
+  --icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(56, 142, 60, 0.999)' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(198, 40, 40, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+}
+@media only screen and (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    color-scheme: dark;
+    --background-color: #11191f;
+    --color: #bbc6ce;
+    --h1-color: #edf0f3;
+    --h2-color: #e1e6eb;
+    --h3-color: #d5dce2;
+    --h4-color: #c8d1d8;
+    --h5-color: #bbc6ce;
+    --h6-color: #afbbc4;
+    --muted-color: #73828c;
+    --muted-border-color: #1f2d38;
+    --primary: #1095c1;
+    --primary-hover: #1ab3e6;
+    --primary-focus: rgba(16, 149, 193, 0.25);
+    --primary-inverse: #fff;
+    --secondary: #596b78;
+    --secondary-hover: #73828c;
+    --secondary-focus: rgba(115, 130, 140, 0.25);
+    --secondary-inverse: #fff;
+    --contrast: #edf0f3;
+    --contrast-hover: #fff;
+    --contrast-focus: rgba(115, 130, 140, 0.25);
+    --contrast-inverse: #000;
+    --mark-background-color: #d1c284;
+    --mark-color: #11191f;
+    --ins-color: #388e3c;
+    --del-color: #c62828;
+    --blockquote-border-color: var(--muted-border-color);
+    --blockquote-footer-color: var(--muted-color);
+    --button-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+    --button-hover-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+    --form-element-background-color: #11191f;
+    --form-element-border-color: #374956;
+    --form-element-color: var(--color);
+    --form-element-placeholder-color: var(--muted-color);
+    --form-element-active-background-color: var(--form-element-background-color);
+    --form-element-active-border-color: var(--primary);
+    --form-element-focus-color: var(--primary-focus);
+    --form-element-disabled-background-color: #2c3d49;
+    --form-element-disabled-border-color: #415462;
+    --form-element-disabled-opacity: 0.5;
+    --form-element-invalid-border-color: #b71c1c;
+    --form-element-invalid-active-border-color: #c62828;
+    --form-element-valid-border-color: #2e7d32;
+    --form-element-valid-active-border-color: #388e3c;
+    --switch-background-color: #374956;
+    --switch-color: var(--primary-inverse);
+    --switch-checked-background-color: var(--primary);
+    --range-border-color: #24333e;
+    --range-active-border-color: #2c3d49;
+    --range-thumb-border-color: var(--background-color);
+    --range-thumb-color: var(--secondary);
+    --range-thumb-hover-color: var(--secondary-hover);
+    --range-thumb-active-color: var(--primary);
+    --table-border-color: var(--muted-border-color);
+    --table-row-stripped-background-color: rgba(115, 130, 140, 0.05);
+    --code-background-color: #18232c;
+    --code-color: var(--muted-color);
+    --code-kbd-background-color: var(--contrast);
+    --code-kbd-color: var(--contrast-inverse);
+    --code-tag-color: #a65980;
+    --code-property-color: #599fa6;
+    --code-value-color: #8c8473;
+    --code-comment-color: #4d606d;
+    --accordion-border-color: var(--muted-border-color);
+    --accordion-active-summary-color: var(--primary);
+    --accordion-close-summary-color: var(--color);
+    --accordion-open-summary-color: var(--muted-color);
+    --card-background-color: #141e26;
+    --card-border-color: #11191f;
+    --card-box-shadow: 0 0.125rem 1rem rgba(0, 0, 0, 0.06),
+      0 0.125rem 2rem rgba(0, 0, 0, 0.12), 0 0 0 0.0625rem rgba(0, 0, 0, 0.036);
+    --card-sectionning-background-color: #18232c;
+    --progress-background-color: #24333e;
+    --progress-color: var(--primary);
+    --loading-spinner-opacity: 0.5;
+    --tooltip-background-color: var(--contrast);
+    --tooltip-color: var(--contrast-inverse);
+    --icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    --icon-date: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='16' y1='2' x2='16' y2='6'%3E%3C/line%3E%3Cline x1='8' y1='2' x2='8' y2='6'%3E%3C/line%3E%3Cline x1='3' y1='10' x2='21' y2='10'%3E%3C/line%3E%3C/svg%3E");
+    --icon-time: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+    --icon-search: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E");
+    --icon-checkbox: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+    --icon-minus: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='5' y1='12' x2='19' y2='12'%3E%3C/line%3E%3C/svg%3E");
+    --icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(46, 125, 50, 0.999)' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+    --icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(183, 28, 28, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+  }
+}
+[data-theme='dark'] {
+  color-scheme: dark;
+  --background-color: #11191f;
+  --color: #bbc6ce;
+  --h1-color: #edf0f3;
+  --h2-color: #e1e6eb;
+  --h3-color: #d5dce2;
+  --h4-color: #c8d1d8;
+  --h5-color: #bbc6ce;
+  --h6-color: #afbbc4;
+  --muted-color: #73828c;
+  --muted-border-color: #1f2d38;
+  --primary: #1095c1;
+  --primary-hover: #1ab3e6;
+  --primary-focus: rgba(16, 149, 193, 0.25);
+  --primary-inverse: #fff;
+  --secondary: #596b78;
+  --secondary-hover: #73828c;
+  --secondary-focus: rgba(115, 130, 140, 0.25);
+  --secondary-inverse: #fff;
+  --contrast: #edf0f3;
+  --contrast-hover: #fff;
+  --contrast-focus: rgba(115, 130, 140, 0.25);
+  --contrast-inverse: #000;
+  --mark-background-color: #d1c284;
+  --mark-color: #11191f;
+  --ins-color: #388e3c;
+  --del-color: #c62828;
+  --blockquote-border-color: var(--muted-border-color);
+  --blockquote-footer-color: var(--muted-color);
+  --button-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  --button-hover-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  --form-element-background-color: #11191f;
+  --form-element-border-color: #374956;
+  --form-element-color: var(--color);
+  --form-element-placeholder-color: var(--muted-color);
+  --form-element-active-background-color: var(--form-element-background-color);
+  --form-element-active-border-color: var(--primary);
+  --form-element-focus-color: var(--primary-focus);
+  --form-element-disabled-background-color: #2c3d49;
+  --form-element-disabled-border-color: #415462;
+  --form-element-disabled-opacity: 0.5;
+  --form-element-invalid-border-color: #b71c1c;
+  --form-element-invalid-active-border-color: #c62828;
+  --form-element-valid-border-color: #2e7d32;
+  --form-element-valid-active-border-color: #388e3c;
+  --switch-background-color: #374956;
+  --switch-color: var(--primary-inverse);
+  --switch-checked-background-color: var(--primary);
+  --range-border-color: #24333e;
+  --range-active-border-color: #2c3d49;
+  --range-thumb-border-color: var(--background-color);
+  --range-thumb-color: var(--secondary);
+  --range-thumb-hover-color: var(--secondary-hover);
+  --range-thumb-active-color: var(--primary);
+  --table-border-color: var(--muted-border-color);
+  --table-row-stripped-background-color: rgba(115, 130, 140, 0.05);
+  --code-background-color: #18232c;
+  --code-color: var(--muted-color);
+  --code-kbd-background-color: var(--contrast);
+  --code-kbd-color: var(--contrast-inverse);
+  --code-tag-color: #a65980;
+  --code-property-color: #599fa6;
+  --code-value-color: #8c8473;
+  --code-comment-color: #4d606d;
+  --accordion-border-color: var(--muted-border-color);
+  --accordion-active-summary-color: var(--primary);
+  --accordion-close-summary-color: var(--color);
+  --accordion-open-summary-color: var(--muted-color);
+  --card-background-color: #141e26;
+  --card-border-color: #11191f;
+  --card-box-shadow: 0 0.125rem 1rem rgba(0, 0, 0, 0.06),
+    0 0.125rem 2rem rgba(0, 0, 0, 0.12), 0 0 0 0.0625rem rgba(0, 0, 0, 0.036);
+  --card-sectionning-background-color: #18232c;
+  --progress-background-color: #24333e;
+  --progress-color: var(--primary);
+  --loading-spinner-opacity: 0.5;
+  --tooltip-background-color: var(--contrast);
+  --tooltip-color: var(--contrast-inverse);
+  --icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-date: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='2' ry='2'%3E%3C/rect%3E%3Cline x1='16' y1='2' x2='16' y2='6'%3E%3C/line%3E%3Cline x1='8' y1='2' x2='8' y2='6'%3E%3C/line%3E%3Cline x1='3' y1='10' x2='21' y2='10'%3E%3C/line%3E%3C/svg%3E");
+  --icon-time: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cpolyline points='12 6 12 12 16 14'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-search: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(162, 175, 185, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E");
+  --icon-checkbox: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-minus: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23FFF' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='5' y1='12' x2='19' y2='12'%3E%3C/line%3E%3C/svg%3E");
+  --icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(46, 125, 50, 0.999)' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  --icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgba(183, 28, 28, 0.999)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+}
+*,
+::after,
+::before {
+  box-sizing: border-box;
+}
+::after,
+::before {
+  text-decoration: inherit;
+  vertical-align: inherit;
+}
+html {
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -ms-text-size-adjust: 100%;
+  background-color: var(--background-color);
+  color: var(--color);
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-rendering: optimizeLegibility;
+  cursor: default;
+}
+main {
+  display: block;
+}
+body {
+  width: 100%;
+  margin: 0;
+}
+body > footer,
+body > header,
+body > main {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding: var(--block-spacing-vertical) 0;
+}
+.container,
+.container-fluid {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--spacing);
+  padding-left: var(--spacing);
+}
+@media (min-width: 576px) {
+  .container {
+    max-width: 510px;
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 700px;
+  }
+}
+@media (min-width: 992px) {
+  .container {
+    max-width: 920px;
+  }
+}
+@media (min-width: 1200px) {
+  .container {
+    max-width: 1130px;
+  }
+}
+section {
+  margin-bottom: var(--block-spacing-vertical);
+}
+.grid {
+  grid-column-gap: var(--grid-spacing-horizontal);
+  grid-row-gap: var(--grid-spacing-vertical);
+  display: grid;
+  grid-template-columns: 1fr;
+  margin: 0;
+}
+@media (min-width: 992px) {
+  .grid {
+    grid-template-columns: repeat(auto-fit, minmax(0%, 1fr));
+  }
+}
+.grid > * {
+  min-width: 0;
+}
+figure {
+  display: block;
+  margin: 0;
+  padding: 0;
+  overflow-x: auto;
+}
+figure figcaption {
+  padding: calc(var(--spacing) * 0.5) 0;
+  color: var(--muted-color);
+}
+b,
+strong {
+  font-weight: bolder;
+}
+sub,
+sup {
+  position: relative;
+  font-size: 0.75em;
+  line-height: 0;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+dl dl,
+dl ol,
+dl ul,
+ol dl,
+ul dl {
+  margin: 0;
+}
+ol ol,
+ol ul,
+ul ol,
+ul ul {
+  margin: 0;
+}
+address,
+blockquote,
+dl,
+figure,
+form,
+ol,
+p,
+pre,
+table,
+ul {
+  margin-top: 0;
+  margin-bottom: var(--typography-spacing-vertical);
+  color: var(--color);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  font-style: normal;
+}
+a {
+  --color: var(--primary);
+  --background-color: transparent;
+  outline: 0;
+  background-color: var(--background-color);
+  color: var(--color);
+  -webkit-text-decoration: var(--text-decoration);
+  text-decoration: var(--text-decoration);
+  transition: background-color var(--transition), color var(--transition),
+    box-shadow var(--transition), -webkit-text-decoration var(--transition);
+  transition: background-color var(--transition), color var(--transition),
+    text-decoration var(--transition), box-shadow var(--transition);
+  transition: background-color var(--transition), color var(--transition),
+    text-decoration var(--transition), box-shadow var(--transition),
+    -webkit-text-decoration var(--transition);
+}
+a:active,
+a:focus,
+a:hover {
+  --color: var(--primary-hover);
+  --text-decoration: underline;
+}
+a:focus {
+  --background-color: var(--primary-focus);
+}
+a.secondary {
+  --color: var(--secondary);
+}
+a.secondary:active,
+a.secondary:focus,
+a.secondary:hover {
+  --color: var(--secondary-hover);
+}
+a.secondary:focus {
+  --background-color: var(--secondary-focus);
+}
+a.contrast {
+  --color: var(--contrast);
+}
+a.contrast:active,
+a.contrast:focus,
+a.contrast:hover {
+  --color: var(--contrast-hover);
+}
+a.contrast:focus {
+  --background-color: var(--contrast-focus);
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  margin-bottom: var(--typography-spacing-vertical);
+  color: var(--color);
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+}
+h1 {
+  --color: var(--h1-color);
+}
+h2 {
+  --color: var(--h2-color);
+}
+h3 {
+  --color: var(--h3-color);
+}
+h4 {
+  --color: var(--h4-color);
+}
+h5 {
+  --color: var(--h5-color);
+}
+h6 {
+  --color: var(--h6-color);
+}
+address ~ h1,
+address ~ h2,
+address ~ h3,
+address ~ h4,
+address ~ h5,
+address ~ h6,
+blockquote ~ h1,
+blockquote ~ h2,
+blockquote ~ h3,
+blockquote ~ h4,
+blockquote ~ h5,
+blockquote ~ h6,
+dl ~ h1,
+dl ~ h2,
+dl ~ h3,
+dl ~ h4,
+dl ~ h5,
+dl ~ h6,
+figure ~ h1,
+figure ~ h2,
+figure ~ h3,
+figure ~ h4,
+figure ~ h5,
+figure ~ h6,
+form ~ h1,
+form ~ h2,
+form ~ h3,
+form ~ h4,
+form ~ h5,
+form ~ h6,
+ol ~ h1,
+ol ~ h2,
+ol ~ h3,
+ol ~ h4,
+ol ~ h5,
+ol ~ h6,
+pre ~ h1,
+pre ~ h2,
+pre ~ h3,
+pre ~ h4,
+pre ~ h5,
+pre ~ h6,
+p ~ h1,
+p ~ h2,
+p ~ h3,
+p ~ h4,
+p ~ h5,
+p ~ h6,
+table ~ h1,
+table ~ h2,
+table ~ h3,
+table ~ h4,
+table ~ h5,
+table ~ h6,
+ul ~ h1,
+ul ~ h2,
+ul ~ h3,
+ul ~ h4,
+ul ~ h5,
+ul ~ h6 {
+  margin-top: var(--typography-spacing-vertical);
+}
+hgroup {
+  margin-bottom: var(--typography-spacing-vertical);
+}
+hgroup > * {
+  margin-bottom: 0;
+}
+hgroup > :last-child {
+  --color: var(--muted-color);
+  --font-weight: unset;
+  font-family: unset;
+  font-size: 1rem;
+}
+p {
+  margin-bottom: var(--typography-spacing-vertical);
+}
+small {
+  font-size: var(--font-size);
+}
+ol,
+ul {
+  padding-right: 0;
+  padding-left: var(--spacing);
+  -webkit-padding-end: 0;
+  padding-inline-end: 0;
+  -webkit-padding-start: var(--spacing);
+  padding-inline-start: var(--spacing);
+}
+ol li,
+ul li {
+  margin-bottom: calc(var(--typography-spacing-vertical) * 0.25);
+}
+ul li {
+  list-style: square;
+}
+mark {
+  padding: 0.125rem 0.25rem;
+  background-color: var(--mark-background-color);
+  color: var(--mark-color);
+  vertical-align: middle;
+}
+blockquote {
+  display: block;
+  margin: var(--typography-spacing-vertical) 0;
+  padding: var(--spacing);
+  border-right: none;
+  border-left: 0.25rem solid var(--blockquote-border-color);
+  -webkit-border-end: none;
+  border-inline-end: none;
+  -webkit-border-start: 0.25rem solid var(--blockquote-border-color);
+  border-inline-start: 0.25rem solid var(--blockquote-border-color);
+}
+blockquote footer {
+  margin-top: calc(var(--typography-spacing-vertical) * 0.5);
+  color: var(--blockquote-footer-color);
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+  text-decoration: none;
+  cursor: help;
+}
+ins {
+  color: var(--ins-color);
+  text-decoration: none;
+}
+del {
+  color: var(--del-color);
+}
+::-moz-selection {
+  background-color: var(--primary-focus);
+}
+::selection {
+  background-color: var(--primary-focus);
+}
+audio,
+canvas,
+iframe,
+img,
+svg,
+video {
+  vertical-align: middle;
+}
+audio,
+video {
+  display: inline-block;
+}
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+iframe {
+  border-style: none;
+}
+img {
+  max-width: 100%;
+  height: auto;
+  border-style: none;
+}
+svg:not([fill]) {
+  fill: currentColor;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+button {
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  text-transform: none;
+}
+[type='button'],
+[type='reset'],
+[type='submit'],
+button {
+  -webkit-appearance: button;
+}
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner,
+button::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+button {
+  display: block;
+  width: 100%;
+  margin-bottom: var(--spacing);
+}
+a[role='button'] {
+  display: inline-block;
+  text-decoration: none;
+}
+a[role='button'],
+button,
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
+  --background-color: var(--primary);
+  --border-color: var(--primary);
+  --color: var(--primary-inverse);
+  --box-shadow: var(--button-box-shadow, 0 0 0 rgba(0, 0, 0, 0));
+  padding: var(--form-element-spacing-vertical)
+    var(--form-element-spacing-horizontal);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-size: 1rem;
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-align: center;
+  cursor: pointer;
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+a[role='button']:active,
+a[role='button']:focus,
+a[role='button']:hover,
+button:active,
+button:focus,
+button:hover,
+input[type='button']:active,
+input[type='button']:focus,
+input[type='button']:hover,
+input[type='reset']:active,
+input[type='reset']:focus,
+input[type='reset']:hover,
+input[type='submit']:active,
+input[type='submit']:focus,
+input[type='submit']:hover {
+  --background-color: var(--primary-hover);
+  --border-color: var(--primary-hover);
+  --box-shadow: var(--button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0));
+}
+a[role='button']:focus,
+button:focus,
+input[type='button']:focus,
+input[type='reset']:focus,
+input[type='submit']:focus {
+  --box-shadow: var(--button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)),
+    0 0 0 var(--outline-width) var(--primary-focus);
+}
+input[type='reset'] {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  cursor: pointer;
+}
+input[type='reset']:active,
+input[type='reset']:focus,
+input[type='reset']:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+input[type='reset']:focus {
+  --box-shadow: var(--button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)),
+    0 0 0 var(--outline-width) var(--secondary-focus);
+}
+a[role='button'].secondary,
+button.secondary,
+input[type='button'].secondary,
+input[type='reset'].secondary,
+input[type='submit'].secondary {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  cursor: pointer;
+}
+a[role='button'].secondary:active,
+a[role='button'].secondary:focus,
+a[role='button'].secondary:hover,
+button.secondary:active,
+button.secondary:focus,
+button.secondary:hover,
+input[type='button'].secondary:active,
+input[type='button'].secondary:focus,
+input[type='button'].secondary:hover,
+input[type='reset'].secondary:active,
+input[type='reset'].secondary:focus,
+input[type='reset'].secondary:hover,
+input[type='submit'].secondary:active,
+input[type='submit'].secondary:focus,
+input[type='submit'].secondary:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+a[role='button'].secondary:focus,
+button.secondary:focus,
+input[type='button'].secondary:focus,
+input[type='reset'].secondary:focus,
+input[type='submit'].secondary:focus {
+  --box-shadow: var(--button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)),
+    0 0 0 var(--outline-width) var(--secondary-focus);
+}
+a[role='button'].contrast,
+button.contrast,
+input[type='button'].contrast,
+input[type='reset'].contrast,
+input[type='submit'].contrast {
+  --background-color: var(--contrast);
+  --border-color: var(--contrast);
+  --color: var(--contrast-inverse);
+}
+a[role='button'].contrast:active,
+a[role='button'].contrast:focus,
+a[role='button'].contrast:hover,
+button.contrast:active,
+button.contrast:focus,
+button.contrast:hover,
+input[type='button'].contrast:active,
+input[type='button'].contrast:focus,
+input[type='button'].contrast:hover,
+input[type='reset'].contrast:active,
+input[type='reset'].contrast:focus,
+input[type='reset'].contrast:hover,
+input[type='submit'].contrast:active,
+input[type='submit'].contrast:focus,
+input[type='submit'].contrast:hover {
+  --background-color: var(--contrast-hover);
+  --border-color: var(--contrast-hover);
+}
+a[role='button'].contrast:focus,
+button.contrast:focus,
+input[type='button'].contrast:focus,
+input[type='reset'].contrast:focus,
+input[type='submit'].contrast:focus {
+  --box-shadow: var(--button-hover-box-shadow, 0 0 0 rgba(0, 0, 0, 0)),
+    0 0 0 var(--outline-width) var(--contrast-focus);
+}
+a[role='button'].outline,
+button.outline,
+input[type='button'].outline,
+input[type='reset'].outline,
+input[type='submit'].outline {
+  --background-color: transparent;
+  --color: var(--primary);
+}
+a[role='button'].outline:active,
+a[role='button'].outline:focus,
+a[role='button'].outline:hover,
+button.outline:active,
+button.outline:focus,
+button.outline:hover,
+input[type='button'].outline:active,
+input[type='button'].outline:focus,
+input[type='button'].outline:hover,
+input[type='reset'].outline:active,
+input[type='reset'].outline:focus,
+input[type='reset'].outline:hover,
+input[type='submit'].outline:active,
+input[type='submit'].outline:focus,
+input[type='submit'].outline:hover {
+  --background-color: transparent;
+  --color: var(--primary-hover);
+}
+a[role='button'].outline.secondary,
+button.outline.secondary,
+input[type='button'].outline.secondary,
+input[type='reset'].outline.secondary,
+input[type='submit'].outline.secondary {
+  --color: var(--secondary);
+}
+a[role='button'].outline.secondary:active,
+a[role='button'].outline.secondary:focus,
+a[role='button'].outline.secondary:hover,
+button.outline.secondary:active,
+button.outline.secondary:focus,
+button.outline.secondary:hover,
+input[type='button'].outline.secondary:active,
+input[type='button'].outline.secondary:focus,
+input[type='button'].outline.secondary:hover,
+input[type='reset'].outline.secondary:active,
+input[type='reset'].outline.secondary:focus,
+input[type='reset'].outline.secondary:hover,
+input[type='submit'].outline.secondary:active,
+input[type='submit'].outline.secondary:focus,
+input[type='submit'].outline.secondary:hover {
+  --color: var(--secondary-hover);
+}
+a[role='button'].outline.contrast,
+button.outline.contrast,
+input[type='button'].outline.contrast,
+input[type='reset'].outline.contrast,
+input[type='submit'].outline.contrast {
+  --color: var(--contrast);
+}
+a[role='button'].outline.contrast:active,
+a[role='button'].outline.contrast:focus,
+a[role='button'].outline.contrast:hover,
+button.outline.contrast:active,
+button.outline.contrast:focus,
+button.outline.contrast:hover,
+input[type='button'].outline.contrast:active,
+input[type='button'].outline.contrast:focus,
+input[type='button'].outline.contrast:hover,
+input[type='reset'].outline.contrast:active,
+input[type='reset'].outline.contrast:focus,
+input[type='reset'].outline.contrast:hover,
+input[type='submit'].outline.contrast:active,
+input[type='submit'].outline.contrast:focus,
+input[type='submit'].outline.contrast:hover {
+  --color: var(--contrast-hover);
+}
+a[role='button'][disabled],
+button[disabled],
+input[type='button'][disabled],
+input[type='reset'][disabled],
+input[type='submit'][disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: 1rem;
+  letter-spacing: inherit;
+  line-height: var(--line-height);
+}
+input {
+  overflow: visible;
+}
+select {
+  text-transform: none;
+}
+legend {
+  max-width: 100%;
+  padding: 0;
+  color: inherit;
+  white-space: normal;
+}
+textarea {
+  overflow: auto;
+}
+[type='checkbox'],
+[type='radio'] {
+  padding: 0;
+}
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+[type='search'] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+:-moz-focusring {
+  outline: 0;
+}
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+::-ms-expand {
+  display: none;
+}
+[type='file'],
+[type='range'] {
+  padding: 0;
+  border-width: 0;
+}
+input:not([type='checkbox']):not([type='radio']):not([type='range']) {
+  height: calc(
+    1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 +
+      var(--border-width) * 2
+  );
+}
+fieldset {
+  margin: 0;
+  margin-bottom: var(--spacing);
+  padding: 0;
+  border: 0;
+}
+fieldset legend,
+label {
+  display: block;
+  margin-bottom: calc(var(--spacing) * 0.25);
+}
+input:not([type='checkbox']):not([type='radio']),
+select,
+textarea {
+  width: 100%;
+}
+input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']),
+select,
+textarea {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding: var(--form-element-spacing-vertical)
+    var(--form-element-spacing-horizontal);
+  vertical-align: middle;
+}
+input,
+select,
+textarea {
+  --background-color: var(--form-element-background-color);
+  --border-color: var(--form-element-border-color);
+  --color: var(--form-element-color);
+  --box-shadow: none;
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-weight: var(--font-weight);
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+input:not([type='submit']):not([type='button']):not([type='reset']):not([type='checkbox']):not([type='radio']):not([readonly]):active,
+input:not([type='submit']):not([type='button']):not([type='reset']):not([type='checkbox']):not([type='radio']):not([readonly]):focus,
+select:active,
+select:focus,
+textarea:active,
+textarea:focus {
+  --background-color: var(--form-element-active-background-color);
+}
+input:not([type='submit']):not([type='button']):not([type='reset']):not([role='switch']):not([readonly]):active,
+input:not([type='submit']):not([type='button']):not([type='reset']):not([role='switch']):not([readonly]):focus,
+select:active,
+select:focus,
+textarea:active,
+textarea:focus {
+  --border-color: var(--form-element-active-border-color);
+}
+input:not([type='submit']):not([type='button']):not([type='reset']):not([type='range']):not([type='file']):not([readonly]):focus,
+select:focus,
+textarea:focus {
+  --box-shadow: 0 0 0 var(--outline-width) var(--form-element-focus-color);
+}
+input:not([type='submit']):not([type='button']):not([type='reset'])[disabled],
+select[disabled],
+textarea[disabled] {
+  --background-color: var(--form-element-disabled-background-color);
+  --border-color: var(--form-element-disabled-border-color);
+  opacity: var(--form-element-disabled-opacity);
+}
+input:not([type='checkbox']):not([type='radio'])[aria-invalid],
+select:not([type='checkbox']):not([type='radio'])[aria-invalid],
+textarea:not([type='checkbox']):not([type='radio'])[aria-invalid] {
+  padding-right: calc(var(--form-element-spacing-horizontal) + 1.5rem) !important;
+  padding-left: var(--form-element-spacing-horizontal);
+  -webkit-padding-end: calc(
+    var(--form-element-spacing-horizontal) + 1.5rem
+  ) !important;
+  padding-inline-end: calc(
+    var(--form-element-spacing-horizontal) + 1.5rem
+  ) !important;
+  -webkit-padding-start: var(--form-element-spacing-horizontal) !important;
+  padding-inline-start: var(--form-element-spacing-horizontal) !important;
+  background-position: center right 0.75rem;
+  background-repeat: no-repeat;
+  background-size: 1rem auto;
+}
+input:not([type='checkbox']):not([type='radio'])[aria-invalid='false'],
+select:not([type='checkbox']):not([type='radio'])[aria-invalid='false'],
+textarea:not([type='checkbox']):not([type='radio'])[aria-invalid='false'] {
+  background-image: var(--icon-valid);
+}
+input:not([type='checkbox']):not([type='radio'])[aria-invalid='true'],
+select:not([type='checkbox']):not([type='radio'])[aria-invalid='true'],
+textarea:not([type='checkbox']):not([type='radio'])[aria-invalid='true'] {
+  background-image: var(--icon-invalid);
+}
+input[aria-invalid='false'],
+select[aria-invalid='false'],
+textarea[aria-invalid='false'] {
+  --border-color: var(--form-element-valid-border-color);
+}
+input[aria-invalid='false']:active,
+input[aria-invalid='false']:focus,
+select[aria-invalid='false']:active,
+select[aria-invalid='false']:focus,
+textarea[aria-invalid='false']:active,
+textarea[aria-invalid='false']:focus {
+  --border-color: var(--form-element-valid-active-border-color) !important;
+}
+input[aria-invalid='true'],
+select[aria-invalid='true'],
+textarea[aria-invalid='true'] {
+  --border-color: var(--form-element-invalid-border-color);
+}
+input[aria-invalid='true']:active,
+input[aria-invalid='true']:focus,
+select[aria-invalid='true']:active,
+select[aria-invalid='true']:focus,
+textarea[aria-invalid='true']:active,
+textarea[aria-invalid='true']:focus {
+  --border-color: var(--form-element-invalid-active-border-color) !important;
+}
+[dir='rtl'] input[aria-invalid],
+[dir='rtl'] select[aria-invalid],
+[dir='rtl'] textarea[aria-invalid] {
+  background-position: center left 0.75rem;
+}
+input::-webkit-input-placeholder,
+input::placeholder,
+select:invalid,
+textarea::-webkit-input-placeholder,
+textarea::placeholder {
+  color: var(--form-element-placeholder-color);
+  opacity: 1;
+}
+input:not([type='checkbox']):not([type='radio']),
+select,
+textarea {
+  margin-bottom: var(--spacing);
+}
+select::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+select:not([multiple]):not([size]) {
+  padding-right: calc(var(--form-element-spacing-horizontal) + 1.5rem);
+  padding-left: var(--form-element-spacing-horizontal);
+  -webkit-padding-end: calc(var(--form-element-spacing-horizontal) + 1.5rem);
+  padding-inline-end: calc(var(--form-element-spacing-horizontal) + 1.5rem);
+  -webkit-padding-start: var(--form-element-spacing-horizontal);
+  padding-inline-start: var(--form-element-spacing-horizontal);
+  background-image: var(--icon-chevron);
+  background-position: center right 0.75rem;
+  background-repeat: no-repeat;
+  background-size: 1rem auto;
+}
+[dir='rtl'] select:not([multiple]):not([size]) {
+  background-position: center left 0.75rem;
+}
+input + small,
+select + small,
+textarea + small {
+  display: block;
+  width: 100%;
+  margin-top: calc(var(--spacing) * -0.75);
+  margin-bottom: var(--spacing);
+  color: var(--muted-color);
+}
+label > input,
+label > select,
+label > textarea {
+  margin-top: calc(var(--spacing) * 0.25);
+}
+[type='checkbox'],
+[type='radio'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 1.25em;
+  height: 1.25em;
+  margin-top: -0.125em;
+  margin-right: 0.375em;
+  margin-left: 0;
+  -webkit-margin-end: 0.375em;
+  margin-inline-end: 0.375em;
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  border-width: var(--border-width);
+  vertical-align: middle;
+  cursor: pointer;
+}
+[type='checkbox']::-ms-check,
+[type='radio']::-ms-check {
+  display: none;
+}
+[type='checkbox']:checked,
+[type='checkbox']:checked:active,
+[type='checkbox']:checked:focus,
+[type='radio']:checked,
+[type='radio']:checked:active,
+[type='radio']:checked:focus {
+  --background-color: var(--primary);
+  --border-color: var(--primary);
+  background-image: var(--icon-checkbox);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 0.75em auto;
+}
+[type='checkbox'] ~ label,
+[type='radio'] ~ label {
+  display: inline-block;
+  margin-right: 0.375em;
+  margin-bottom: 0;
+  cursor: pointer;
+}
+[type='checkbox']:indeterminate {
+  --background-color: var(--primary);
+  --border-color: var(--primary);
+  background-image: var(--icon-minus);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 0.75em auto;
+}
+[type='radio'] {
+  border-radius: 50%;
+}
+[type='radio']:checked,
+[type='radio']:checked:active,
+[type='radio']:checked:focus {
+  --background-color: var(--primary-inverse);
+  border-width: 0.35em;
+  background-image: none;
+}
+[type='checkbox'][role='switch'] {
+  --background-color: var(--switch-background-color);
+  --border-color: var(--switch-background-color);
+  --color: var(--switch-color);
+  width: 2.25em;
+  height: 1.25em;
+  border: var(--border-width) solid var(--border-color);
+  border-radius: 1.25em;
+  background-color: var(--background-color);
+  line-height: 1.25em;
+}
+[type='checkbox'][role='switch']:focus {
+  --background-color: var(--switch-background-color);
+  --border-color: var(--switch-background-color);
+}
+[type='checkbox'][role='switch']:checked {
+  --background-color: var(--switch-checked-background-color);
+  --border-color: var(--switch-checked-background-color);
+}
+[type='checkbox'][role='switch']:before {
+  display: block;
+  width: calc(1.25em - (var(--border-width) * 2));
+  height: 100%;
+  border-radius: 50%;
+  background-color: var(--color);
+  content: '';
+  transition: margin 0.1s ease-in-out;
+}
+[type='checkbox'][role='switch']:checked {
+  background-image: none;
+}
+[type='checkbox'][role='switch']:checked::before {
+  margin-right: 0;
+  margin-left: calc(1.125em - var(--border-width));
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+  -webkit-margin-start: calc(1.125em - var(--border-width));
+  margin-inline-start: calc(1.125em - var(--border-width));
+}
+[type='checkbox'][role='switch'][aria-invalid='false'] {
+  --border-color: var(--form-element-valid-border-color);
+}
+[type='checkbox'][role='switch'][aria-invalid='false']:active,
+[type='checkbox'][role='switch'][aria-invalid='false']:focus {
+  --border-color: var(--form-element-valid-active-border-color) !important;
+}
+[type='checkbox'][role='switch'][aria-invalid='true'] {
+  --border-color: var(--form-element-invalid-border-color);
+}
+[type='checkbox'][role='switch'][aria-invalid='true']:active,
+[type='checkbox'][role='switch'][aria-invalid='true']:focus {
+  --border-color: var(--form-element-invalid-active-border-color) !important;
+}
+[type='color']::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+[type='color']::-moz-focus-inner {
+  padding: 0;
+}
+[type='color']::-webkit-color-swatch {
+  border: none;
+  border-radius: calc(var(--border-radius) * 0.5);
+}
+[type='color']::-moz-color-swatch {
+  border: none;
+  border-radius: calc(var(--border-radius) * 0.5);
+}
+:not(:dir(rtl)) [type='date'],
+:not(:dir(rtl)) [type='datetime-local'],
+:not(:dir(rtl)) [type='month'],
+:not(:dir(rtl)) [type='time'],
+:not(:dir(rtl)) [type='week'] {
+  background-image: var(--icon-date);
+  background-position: center right 0.75rem;
+  background-repeat: no-repeat;
+  background-size: 1rem auto;
+}
+:not(:dir(rtl)) [type='date']::-webkit-calendar-picker-indicator,
+:not(:dir(rtl)) [type='datetime-local']::-webkit-calendar-picker-indicator,
+:not(:dir(rtl)) [type='month']::-webkit-calendar-picker-indicator,
+:not(:dir(rtl)) [type='time']::-webkit-calendar-picker-indicator,
+:not(:dir(rtl)) [type='week']::-webkit-calendar-picker-indicator {
+  opacity: 0;
+}
+:not(:dir(rtl)) [type='time'] {
+  background-image: var(--icon-time);
+}
+[type='file'] {
+  --color: var(--muted-color);
+  padding: calc(var(--form-element-spacing-vertical) * 0.5) 0;
+  border: none;
+  border-radius: 0;
+  background: 0 0;
+}
+[type='file']:active,
+[type='file']:focus,
+[type='file']:hover {
+  border: none;
+  background: 0 0;
+}
+[type='file']::-webkit-file-upload-button {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  margin-right: calc(var(--spacing) / 2);
+  margin-left: 0;
+  -webkit-margin-end: calc(var(--spacing) / 2);
+  margin-inline-end: calc(var(--spacing) / 2);
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  padding: calc(var(--form-element-spacing-vertical) * 0.5)
+    calc(var(--form-element-spacing-horizontal) * 0.5);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-size: 1rem;
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-align: center;
+  cursor: pointer;
+  -webkit-transition: background-color var(--transition),
+    border-color var(--transition), color var(--transition),
+    box-shadow var(--transition);
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+[type='file']::file-selector-button {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  margin-right: calc(var(--spacing) / 2);
+  margin-left: 0;
+  -webkit-margin-end: calc(var(--spacing) / 2);
+  margin-inline-end: calc(var(--spacing) / 2);
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  padding: calc(var(--form-element-spacing-vertical) * 0.5)
+    calc(var(--form-element-spacing-horizontal) * 0.5);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-size: 1rem;
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-align: center;
+  cursor: pointer;
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+[type='file']::-webkit-file-upload-button:active,
+[type='file']::-webkit-file-upload-button:focus,
+[type='file']::-webkit-file-upload-button:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+[type='file']::file-selector-button:active,
+[type='file']::file-selector-button:focus,
+[type='file']::file-selector-button:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+[type='file']::-webkit-file-upload-button {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  margin-right: calc(var(--spacing) / 2);
+  margin-left: 0;
+  -webkit-margin-end: calc(var(--spacing) / 2);
+  margin-inline-end: calc(var(--spacing) / 2);
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  padding: calc(var(--form-element-spacing-vertical) * 0.5)
+    calc(var(--form-element-spacing-horizontal) * 0.5);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-size: 1rem;
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-align: center;
+  cursor: pointer;
+  -webkit-transition: background-color var(--transition),
+    border-color var(--transition), color var(--transition),
+    box-shadow var(--transition);
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+[type='file']::-webkit-file-upload-button:active,
+[type='file']::-webkit-file-upload-button:focus,
+[type='file']::-webkit-file-upload-button:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+[type='file']::-ms-browse {
+  --background-color: var(--secondary);
+  --border-color: var(--secondary);
+  --color: var(--secondary-inverse);
+  margin-right: calc(var(--spacing) / 2);
+  margin-left: 0;
+  margin-inline-end: calc(var(--spacing) / 2);
+  margin-inline-start: 0;
+  padding: calc(var(--form-element-spacing-vertical) * 0.5)
+    calc(var(--form-element-spacing-horizontal) * 0.5);
+  border: var(--border-width) solid var(--border-color);
+  border-radius: var(--border-radius);
+  outline: 0;
+  background-color: var(--background-color);
+  box-shadow: var(--box-shadow);
+  color: var(--color);
+  font-size: 1rem;
+  font-weight: var(--font-weight);
+  line-height: var(--line-height);
+  text-align: center;
+  cursor: pointer;
+  -ms-transition: background-color var(--transition),
+    border-color var(--transition), color var(--transition),
+    box-shadow var(--transition);
+  transition: background-color var(--transition), border-color var(--transition),
+    color var(--transition), box-shadow var(--transition);
+}
+[type='file']::-ms-browse:active,
+[type='file']::-ms-browse:focus,
+[type='file']::-ms-browse:hover {
+  --background-color: var(--secondary-hover);
+  --border-color: var(--secondary-hover);
+}
+[type='range'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 1.25rem;
+  background: 0 0;
+}
+[type='range']::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.25rem;
+  border-radius: var(--border-radius);
+  background-color: var(--range-border-color);
+  -webkit-transition: background-color var(--transition),
+    box-shadow var(--transition);
+  transition: background-color var(--transition), box-shadow var(--transition);
+}
+[type='range']::-moz-range-track {
+  width: 100%;
+  height: 0.25rem;
+  border-radius: var(--border-radius);
+  background-color: var(--range-border-color);
+  -moz-transition: background-color var(--transition),
+    box-shadow var(--transition);
+  transition: background-color var(--transition), box-shadow var(--transition);
+}
+[type='range']::-ms-track {
+  width: 100%;
+  height: 0.25rem;
+  border-radius: var(--border-radius);
+  background-color: var(--range-border-color);
+  -ms-transition: background-color var(--transition), box-shadow var(--transition);
+  transition: background-color var(--transition), box-shadow var(--transition);
+}
+[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: -0.5rem;
+  border: 2px solid var(--range-thumb-border-color);
+  border-radius: 50%;
+  background-color: var(--range-thumb-color);
+  cursor: pointer;
+  -webkit-transition: background-color var(--transition),
+    transform var(--transition);
+  transition: background-color var(--transition), transform var(--transition);
+}
+[type='range']::-moz-range-thumb {
+  -webkit-appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: -0.5rem;
+  border: 2px solid var(--range-thumb-border-color);
+  border-radius: 50%;
+  background-color: var(--range-thumb-color);
+  cursor: pointer;
+  -moz-transition: background-color var(--transition), transform var(--transition);
+  transition: background-color var(--transition), transform var(--transition);
+}
+[type='range']::-ms-thumb {
+  -webkit-appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: -0.5rem;
+  border: 2px solid var(--range-thumb-border-color);
+  border-radius: 50%;
+  background-color: var(--range-thumb-color);
+  cursor: pointer;
+  -ms-transition: background-color var(--transition), transform var(--transition);
+  transition: background-color var(--transition), transform var(--transition);
+}
+[type='range']:focus,
+[type='range']:hover {
+  --range-border-color: var(--range-active-border-color);
+  --range-thumb-color: var(--range-thumb-hover-color);
+}
+[type='range']:active {
+  --range-thumb-color: var(--range-thumb-active-color);
+}
+[type='range']:active::-webkit-slider-thumb {
+  transform: scale(1.25);
+}
+[type='range']:active::-moz-range-thumb {
+  transform: scale(1.25);
+}
+[type='range']:active::-ms-thumb {
+  transform: scale(1.25);
+}
+[type='search'] {
+  border-radius: 5rem;
+  padding-left: calc(var(--form-element-spacing-horizontal) + 1.75rem) !important;
+  background-image: var(--icon-search);
+  background-position: center left 1.125rem;
+  background-repeat: no-repeat;
+  background-size: 1rem auto;
+}
+[type='search']::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  display: none;
+}
+table {
+  width: 100%;
+  border-color: inherit;
+  border-collapse: collapse;
+  border-spacing: 0;
+  text-indent: 0;
+}
+td,
+th {
+  padding: calc(var(--spacing) / 2) var(--spacing);
+  border-bottom: var(--border-width) solid var(--table-border-color);
+  color: var(--color);
+  font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  text-align: left;
+  text-align: start;
+}
+tr {
+  background-color: var(--background-color);
+}
+table[role='grid'] tbody tr:nth-child(odd) {
+  --background-color: var(--table-row-stripped-background-color);
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--font-family);
+  font-size: 0.875em;
+}
+pre {
+  -ms-overflow-style: scrollbar;
+  overflow: auto;
+}
+code,
+kbd,
+pre {
+  background: var(--code-background-color);
+  color: var(--code-color);
+  font-weight: var(--font-weight);
+  line-height: initial;
+  border-radius: var(--border-radius);
+}
+code,
+kbd {
+  display: inline-block;
+  padding: 0.375rem 0.5rem;
+}
+pre {
+  display: block;
+  margin-bottom: var(--spacing);
+  overflow-x: auto;
+}
+pre > code {
+  background: 0 0;
+  display: block;
+  padding: var(--spacing);
+  font-size: 14px;
+  line-height: var(--line-height);
+}
+code b {
+  color: var(--code-tag-color);
+  font-weight: var(--font-weight);
+}
+code i {
+  color: var(--code-property-color);
+  font-style: normal;
+}
+code u {
+  color: var(--code-value-color);
+  text-decoration: none;
+}
+code em {
+  color: var(--code-comment-color);
+  font-style: normal;
+}
+kbd {
+  background-color: var(--code-kbd-background-color);
+  color: var(--code-kbd-color);
+  vertical-align: middle;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+  border: none;
+  border-top: 1px solid var(--muted-border-color);
+}
+[hidden],
+template {
+  display: none !important;
+}
+dialog {
+  display: block;
+  position: absolute;
+  right: 0;
+  left: 0;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+  height: -moz-fit-content;
+  height: -webkit-fit-content;
+  height: fit-content;
+  margin: auto;
+  padding: 1em;
+  border: solid;
+  background-color: #fff;
+  color: #000;
+}
+dialog:not([open]) {
+  display: none;
+}
+canvas {
+  display: inline-block;
+}
+details {
+  display: block;
+  margin-bottom: var(--spacing);
+  padding-bottom: calc(var(--spacing) * 0.5);
+  border-bottom: var(--border-width) solid var(--accordion-border-color);
+}
+details summary {
+  color: var(--accordion-close-summary-color);
+  line-height: 1rem;
+  list-style-type: none;
+  cursor: pointer;
+  transition: color var(--transition);
+}
+details summary::-webkit-details-marker {
+  display: none;
+}
+details summary::marker {
+  display: none;
+}
+details summary::-moz-list-bullet {
+  list-style-type: none;
+}
+details summary::after {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  float: right;
+  transform: rotate(-90deg);
+  background-image: var(--icon-chevron);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 1rem auto;
+  content: '';
+  transition: transform var(--transition);
+}
+details summary:focus {
+  outline: 0;
+  color: var(--accordion-active-summary-color);
+}
+details summary ~ * {
+  margin-top: calc(var(--spacing) * 0.5);
+}
+details summary ~ * ~ * {
+  margin-top: 0;
+}
+details[open] > summary {
+  margin-bottom: calc(var(--spacing) * 0.25);
+}
+details[open] > summary:not(:focus) {
+  color: var(--accordion-open-summary-color);
+}
+details[open] > summary::after {
+  transform: rotate(0);
+}
+[dir='rtl'] details summary::after {
+  float: left;
+}
+article {
+  margin: var(--block-spacing-vertical) 0;
+  padding: var(--block-spacing-vertical) var(--block-spacing-horizontal);
+  overflow: hidden;
+  border-radius: var(--border-radius);
+  background: var(--card-background-color);
+  box-shadow: var(--card-box-shadow);
+}
+article > footer,
+article > header {
+  margin-right: calc(var(--block-spacing-horizontal) * -1);
+  margin-left: calc(var(--block-spacing-horizontal) * -1);
+  padding: calc(var(--block-spacing-vertical) * 0.66)
+    var(--block-spacing-horizontal);
+  background-color: var(--card-sectionning-background-color);
+}
+article > header {
+  margin-top: calc(var(--block-spacing-vertical) * -1);
+  margin-bottom: var(--block-spacing-vertical);
+  border-bottom: var(--border-width) solid var(--card-border-color);
+}
+article > footer {
+  margin-top: var(--block-spacing-vertical);
+  margin-bottom: calc(var(--block-spacing-vertical) * -1);
+  border-top: var(--border-width) solid var(--card-border-color);
+}
+nav,
+nav ul {
+  display: flex;
+}
+nav {
+  justify-content: space-between;
+}
+nav ol,
+nav ul {
+  align-items: center;
+  margin-bottom: 0;
+  padding: 0;
+  list-style: none;
+}
+nav ol:first-of-type,
+nav ul:first-of-type {
+  margin-left: calc(var(--spacing) * -0.5);
+}
+nav ol:last-of-type,
+nav ul:last-of-type {
+  margin-right: calc(var(--spacing) * -0.5);
+}
+nav li {
+  display: inline-block;
+  margin: 0;
+  padding: var(--spacing) calc(var(--spacing) * 0.5);
+}
+nav li > *,
+nav li > input:not([type='checkbox']):not([type='radio']) {
+  margin-bottom: 0;
+}
+nav a {
+  display: block;
+  margin: calc(var(--spacing) * -1) calc(var(--spacing) * -0.5);
+  padding: var(--spacing) calc(var(--spacing) * 0.5);
+  border-radius: var(--border-radius);
+  text-decoration: none;
+}
+nav a:active,
+nav a:focus,
+nav a:hover {
+  text-decoration: none;
+}
+aside li,
+aside nav,
+aside ol,
+aside ul {
+  display: block;
+}
+aside li {
+  padding: calc(var(--spacing) * 0.5);
+}
+aside li a {
+  margin: calc(var(--spacing) * -0.5);
+  padding: calc(var(--spacing) * 0.5);
+}
+progress {
+  display: inline-block;
+  vertical-align: baseline;
+}
+progress {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: inline-block;
+  width: 100%;
+  height: 0.5rem;
+  margin-bottom: calc(var(--spacing) * 0.5);
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--border-radius);
+  background-color: var(--progress-background-color);
+  color: var(--progress-color);
+}
+progress::-webkit-progress-bar {
+  border-radius: var(--border-radius);
+  background: 0 0;
+}
+progress[value]::-webkit-progress-value {
+  background-color: var(--progress-color);
+}
+progress::-moz-progress-bar {
+  background-color: var(--progress-color);
+}
+@media (prefers-reduced-motion: no-preference) {
+  progress:indeterminate {
+    background: var(--progress-background-color)
+      linear-gradient(
+        to right,
+        var(--progress-color) 30%,
+        var(--progress-background-color) 30%
+      )
+      top left/150% 150% no-repeat;
+    -webkit-animation: progressIndeterminate 1s linear infinite;
+    animation: progressIndeterminate 1s linear infinite;
+  }
+  progress:indeterminate[value]::-webkit-progress-value {
+    background-color: transparent;
+  }
+  progress:indeterminate::-moz-progress-bar {
+    background-color: transparent;
+  }
+}
+@-webkit-keyframes progressIndeterminate {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+@keyframes progressIndeterminate {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+[aria-busy='true'] {
+  cursor: progress;
+}
+[aria-busy='true']:not(input):not(select):not(textarea)::before {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 0.1875em solid currentColor;
+  border-radius: 1em;
+  border-right-color: transparent;
+  vertical-align: text-bottom;
+  vertical-align: -0.125em;
+  -webkit-animation: spinner 0.75s linear infinite;
+  animation: spinner 0.75s linear infinite;
+  content: '';
+  opacity: var(--loading-spinner-opacity);
+}
+[aria-busy='true']:not(input):not(select):not(textarea):not(:empty)::before {
+  margin-right: calc(var(--spacing) * 0.5);
+  margin-left: 0;
+  -webkit-margin-end: calc(var(--spacing) * 0.5);
+  margin-inline-end: calc(var(--spacing) * 0.5);
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+}
+[aria-busy='true']:not(input):not(select):not(textarea):empty {
+  text-align: center;
+}
+a[aria-busy='true'],
+button[aria-busy='true'],
+input[type='button'][aria-busy='true'],
+input[type='reset'][aria-busy='true'],
+input[type='submit'][aria-busy='true'] {
+  pointer-events: none;
+}
+@-webkit-keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+[data-tooltip] {
+  position: relative;
+}
+[data-tooltip]:not(a):not(button):not(input) {
+  border-bottom: 1px dotted;
+  text-decoration: none;
+  cursor: help;
+}
+[data-tooltip]::after,
+[data-tooltip]::before {
+  display: block;
+  z-index: 99;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  padding: 0.25rem 0.5rem;
+  overflow: hidden;
+  transform: translate(-50%, -0.25rem);
+  border-radius: var(--border-radius);
+  background: var(--tooltip-background-color);
+  color: var(--tooltip-color);
+  font-size: 0.875rem;
+  font-style: normal;
+  font-weight: var(--font-weight);
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  content: attr(data-tooltip);
+  opacity: 0;
+  pointer-events: none;
+}
+[data-tooltip]::after {
+  padding: 0;
+  transform: translate(-50%, 0);
+  border-top: 0.3rem solid;
+  border-right: 0.3rem solid transparent;
+  border-left: 0.3rem solid transparent;
+  border-radius: 0;
+  background-color: transparent;
+  color: var(--tooltip-background-color);
+  content: '';
+}
+[data-tooltip]:focus::after,
+[data-tooltip]:focus::before,
+[data-tooltip]:hover::after,
+[data-tooltip]:hover::before {
+  opacity: 1;
+  -webkit-animation-name: slide;
+  animation-name: slide;
+  -webkit-animation-duration: 0.2s;
+  animation-duration: 0.2s;
+}
+[data-tooltip]:focus::after,
+[data-tooltip]:hover::after {
+  -webkit-animation-name: slideCaret;
+  animation-name: slideCaret;
+}
+@-webkit-keyframes slide {
+  from {
+    transform: translate(-50%, 0.75rem);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, -0.25rem);
+    opacity: 1;
+  }
+}
+@keyframes slide {
+  from {
+    transform: translate(-50%, 0.75rem);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, -0.25rem);
+    opacity: 1;
+  }
+}
+@-webkit-keyframes slideCaret {
+  from {
+    opacity: 0;
+  }
+  50% {
+    transform: translate(-50%, -0.25rem);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+}
+@keyframes slideCaret {
+  from {
+    opacity: 0;
+  }
+  50% {
+    transform: translate(-50%, -0.25rem);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+}
+[aria-controls] {
+  cursor: pointer;
+}
+[aria-disabled='true'],
+[disabled] {
+  cursor: not-allowed;
+}
+[aria-hidden='false'][hidden] {
+  display: initial;
+}
+[aria-hidden='false'][hidden]:not(:focus) {
+  clip: rect(0, 0, 0, 0);
+  position: absolute;
+}
+[tabindex],
+a,
+area,
+button,
+input,
+label,
+select,
+summary,
+textarea {
+  -ms-touch-action: manipulation;
+}
+[dir='rtl'] {
+  direction: rtl;
+}
+@media (prefers-reduced-motion: reduce) {
+  :not([aria-busy='true']),
+  :not([aria-busy='true'])::after,
+  :not([aria-busy='true'])::before {
+    background-attachment: initial !important;
+    -webkit-animation-duration: 1ms !important;
+    animation-duration: 1ms !important;
+    -webkit-animation-delay: -1ms !important;
+    animation-delay: -1ms !important;
+    -webkit-animation-iteration-count: 1 !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+  }
+}

--- a/gs_packages/gem-srv/src/modules/appcore/ac-editmgr.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-editmgr.ts
@@ -427,7 +427,7 @@ function SaveSlotLineScript(event) {
   const { slots_linescript } = SLOTCORE.State();
   const lineIdx = CHECK.OffsetLineNum(sel_linenum, 'sub'); // 1-based
   const lsos = TRANSPILER.ScriptPageToEditableTokens(script_page);
-  const updatedLine = lsos[lineIdx]; // clone existing line to retain block info
+  const lineToUpdate = lsos[lineIdx]; // clone existing line to retain block info
 
   // HACK Block Support -------------------------------------------------------
   // When adding a new line, insert a block if the it's required
@@ -441,7 +441,7 @@ function SaveSlotLineScript(event) {
     )
   )
     isBlockCommand = true;
-  // 2. Is block command? e.g. 'createAgent' or 'spawnChild' featCall
+  // 2. Is featCall block command? e.g. 'createAgent' or 'spawnChild'
   if (String(new_kw).toLowerCase() === 'featcall') {
     slots_linescript.forEach(tok => {
       if (
@@ -460,7 +460,7 @@ function SaveSlotLineScript(event) {
     });
   }
   // 3. Already has a block?
-  const hasBlock = updatedLine.marker === 'start';
+  const hasBlock = lineToUpdate.marker === 'start';
   // 4. Add a block if needed!
   if (isBlockCommand && !hasBlock) {
     slots_linescript.push({
@@ -469,7 +469,7 @@ function SaveSlotLineScript(event) {
   }
   // END HACK Block Support ---------------------------------------------------
 
-  updatedLine.lineScript = slots_linescript.filter(({ identifier }) => {
+  lineToUpdate.lineScript = slots_linescript.filter(({ identifier }) => {
     // SelectEditorLineSlot() treats lineScript tokens as "view data" and
     // stores { identifier:'' } as part of its GUI operation, but this is an
     // illegal script token so we can't just send it as a real token...filtering
@@ -478,7 +478,7 @@ function SaveSlotLineScript(event) {
     if (identifier === '') return false;
     return true;
   }); // just update the lineScript
-  lsos.splice(lineIdx, 1, updatedLine);
+  lsos.splice(lineIdx, 1, lineToUpdate);
   const nscript = TRANSPILER.EditableTokensToScript(lsos);
   WIZCORE.SendState({ script_tokens: nscript });
   SLOTCORE.SendState({ slots_need_saving: false });

--- a/gs_packages/gem-srv/src/modules/appcore/ac-preferences.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-preferences.ts
@@ -1,0 +1,82 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  Site-wide Preferences
+
+  Preferences are shared among all projects.
+  Preferences are defined in the assets/preferences folder.
+
+  (Note that project 'metadata' are project-specific settings
+  while 'preferences' apply to all projects.)
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import UR from '@gemstep/ursys/client';
+import * as CHELPER from 'script/tools/comment-utilities';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('AC-PREFERENCES', 'TagCyan');
+
+/// The module name will be used as args for UR.ReadStateGroups
+const STATE = new UR.class.StateGroupMgr('preferences');
+/// StateGroup keys must be unique across the entire app
+STATE.initializeState({
+  commentTypes: []
+});
+/// These are the primary methods you'll need to use to read and write
+/// state on the behalf of code using APPCORE.
+const { stateObj, flatStateValue, _getKey, updateKey } = STATE;
+/// For handling state change subscribers, export these functions
+const { subscribe, unsubcribe } = STATE;
+/// For React components to send state changes, export this function
+const { handleChange } = STATE;
+/// For publishing state change, this can be used inside this module
+/// DO NOT CALL THIS FROM OUTSIDE
+const { _publishState } = STATE;
+/// To allow outside code to modify state change requests on-the-fly,
+/// export these functions
+const { addChangeHook, deleteChangeHook } = STATE;
+const { addEffectHook, deleteEffectHook } = STATE;
+
+/// CONVENIENCE METHODS ///////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function updateAndPublish(settings) {
+  updateKey({ settings });
+  _publishState({ settings });
+}
+
+/// ACCESSORS /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// return copies
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetPreferences() {
+  // Currently this only returns the comment types, but there's room to
+  // add other preferences
+  return CHELPER.GetCommentTypes();
+
+  // REVIEW: Should this use state?
+  // return { ..._getKey('commentTypes') }; // clone
+}
+
+/// UPDATERS //////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** API: Use this to initialize the data
+ *  This will trigger a state update without writing to disk.
+ */
+function SetPreferences(preferences) {
+  const commentTypes = preferences.commentTypes;
+  commentTypes.forEach(s => {
+    CHELPER.AddStyle(s);
+  });
+
+  // REVIEW: Do we want to update state at all here?
+  // or just rely on CHELPER to maintain state?
+  // DCPROJECT.UpdateProjectData({ commentTypes });
+  // updateAndPublish(settings);
+}
+
+/// EXPORTS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export { GetPreferences, SetPreferences };

--- a/gs_packages/gem-srv/src/modules/appcore/ac-project.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-project.ts
@@ -65,11 +65,13 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import UR from '@gemstep/ursys/client';
+import * as TOML from '@iarna/toml';
 import * as DCPROJECT from 'modules/datacore/dc-project';
 import * as ACMetadata from './ac-metadata';
 import * as ACRounds from './ac-rounds';
 import * as ACBlueprints from './ac-blueprints';
 import * as ACInstances from './ac-instances';
+import * as ACPreferences from './ac-preferences';
 import ERROR from 'modules/error-mgr';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -209,6 +211,9 @@ async function LoadProjectFromAsset(projId) {
     ACRounds.SetRounds(projId, project.rounds);
     ACBlueprints.SetBlueprints(projId, project.blueprints);
     ACInstances.SetInstances(projId, project.instances);
+    // Update Comment Styles from _comment_types.toml
+    const preferences = await DCPROJECT.PreferencesFileLoadFromAsset();
+    ACPreferences.SetPreferences(TOML.parse(preferences));
     // Update datacore
     DCPROJECT.SetCurrentProject(project);
     updateAndPublish(project);

--- a/gs_packages/gem-srv/src/modules/appcore/ac-wizcore.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-wizcore.ts
@@ -603,6 +603,12 @@ export function UpdateDBGConsole(validationLog: string[] = []) {
   buf.set(validationLog);
 }
 
+/// CONSOLE TOOL CALLS ////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+UR.AddConsoleTool('dumpstore', () => {
+  console.log('WIZCORE', STORE.State());
+});
+
 /// EXPORTED STATE METHODS ////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const { State, SendState, SubscribeState, UnsubscribeState, QueueEffect } = STORE;

--- a/gs_packages/gem-srv/src/modules/asset_core/as-load-preferences.ts
+++ b/gs_packages/gem-srv/src/modules/asset_core/as-load-preferences.ts
@@ -1,0 +1,112 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  PREFERENCES LOADER for ASSET MANAGER
+
+  ROLE:
+    Manages and stores a type of asset on behalf of manager
+    Loads assets as a read-only resource into its own dictionary.
+
+  PATTERNS:
+    Assets have an id that is unique across all asset types that is assigned
+    by the asset manifest.
+
+    Loaders are initialized by passing an asset list to queueAssetList(),
+    but the assets are not loaded until promiseLoadAssetList() is
+    called.
+
+    Retrieving assets is handled by the base class. Since assets all
+    have a universal ID system, it is possible for the base clase
+    to provide a consistent interface across multiple types of assets.
+
+  See `class-asset-loader` for the underlying utility methods.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import UR from '@gemstep/ursys/client';
+import AssetLoader from './class-asset-loader';
+import ERROR from 'modules/error-mgr';
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const PR = UR.PrefixUtil('AS-PREFERENCES');
+
+/// CLASS DEFINITION //////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class PreferencesLoader extends AssetLoader {
+  _loadCount: number;
+
+  constructor() {
+    super('preferences');
+    this._loadCount = 0;
+  }
+
+  /// INHERITED FROM ASSETLOADER BASE CLASS ///////////////////////////////////
+  /// see class-asset-loader for provided methods
+
+  /// LOADER-SPECIFIC METHOD OVERRIDES and METHODS ////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** override this method to write custom asset list queue */
+  queueAssetList(assetList: TAssetDef[]) {
+    assetList.forEach(item => {
+      const { assetId, assetName, assetUrl } = item;
+      if (typeof assetId !== 'number') throw Error('bad/missing assetId in list');
+      if (!(assetId && assetName && assetUrl)) throw Error('bad asset list');
+      this._queueAsset(assetId, assetName, assetUrl);
+    });
+  }
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** override this method to implement own loader. should return a promise
+   *  that will be added to an array of Promises to exist during ASSET_LOAD
+   */
+  promiseLoadAssets(): Promise<TAssetDef[]> {
+    const promises = [];
+
+    let item: TAssetDef = this._nextAsset();
+    while (item !== undefined) {
+      this._saveAsset(item); // write stub without resource to lookup later
+      const { assetName, assetUrl } = item;
+      const assetId = this.lookupAssetId(assetName);
+      // note: fetch returns a promise, so you don't need to wrap it in one
+      const promiseFetch = fetch(assetUrl)
+        .then(response => {
+          if (!response.ok) throw new Error('network error');
+          return response.text();
+        })
+        .then(result => {
+          try {
+            const paths = assetUrl.split('/');
+            const filename = paths[paths.length - 1];
+            const url = encodeURIComponent(filename.split('.')[0]);
+            this._saveAsset({ assetId, assetName }, result);
+          } catch (err) {
+            console.error(...PR(`parse error ${err} on ${assetName}`));
+          }
+        });
+      promises.push(promiseFetch);
+      item = this._nextAsset();
+    } // end while
+    return Promise.all(promises);
+  }
+
+  /// ASSET TYPE-SPECIFIC OPERATIONS //////////////////////////////////////////
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** Returns project matching projId (not assetId) */
+  getPreferences() {
+    const preferencesassets = [...this._assetDict.values()];
+    const preferencesasset = preferencesassets.find(a => {
+      if (!a.rsrc) {
+        ERROR(`could not load resources for settings`, {
+          source: 'assets',
+          data: { a }
+        });
+        return undefined;
+      }
+      return a.rsrc;
+    });
+    return preferencesasset ? preferencesasset.rsrc : undefined;
+  }
+} // end class
+
+/// EXPORTS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export default PreferencesLoader;

--- a/gs_packages/gem-srv/src/modules/asset_core/asset-mgr.ts
+++ b/gs_packages/gem-srv/src/modules/asset_core/asset-mgr.ts
@@ -34,6 +34,7 @@ import UR from '@gemstep/ursys/client';
 import { GS_ASSETS_ROUTE, GS_ASSETS_PATH } from 'config/gem-settings';
 import SpriteLoader from './as-load-sprites';
 import ProjectLoader from './as-load-projects';
+import PreferencesLoader from './as-load-preferences';
 import AssetLoader from './class-asset-loader';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -141,6 +142,7 @@ function DBG_ForceLoadAsset(subdir) {
 /// register for every type within this asset manager
 m_RegisterLoader(new SpriteLoader());
 m_RegisterLoader(new ProjectLoader());
+m_RegisterLoader(new PreferencesLoader());
 
 /// EXPORTS ///////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/gem-srv/src/modules/datacore/class-gemprj-data.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/class-gemprj-data.ts
@@ -27,6 +27,7 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import ProjectLoader from 'modules/asset_core/as-load-projects';
+import PreferencesLoader from 'modules/asset_core/as-load-preferences';
 import { NormalizePath } from 'lib/util-path';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -37,6 +38,7 @@ const DBG = false;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 class GEM_ProjectData {
   loader: ProjectLoader;
+  preferencesloader: PreferencesLoader;
   manifest: TManifest;
   asset_url: string;
 
@@ -121,6 +123,13 @@ class GEM_ProjectData {
     }
     if (DBG && match === undefined) console.error(`${fn} no match ${bpName}`);
     return match;
+  }
+
+  getPreferences() {
+    if (this.preferencesloader === undefined)
+      throw Error('GetPreferences: no settings loaded');
+    const preferences = this.preferencesloader.getPreferences();
+    return preferences;
   }
 
   /// ACCESSORS FOR DATA STRUCTURES ///////////////////////////////////////////

--- a/gs_packages/gem-srv/src/modules/datacore/dc-project-db.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-project-db.ts
@@ -1,0 +1,356 @@
+/// DEPRECATED dc-project calls 2022-0423
+/// These were the original GraphQL Calls used by dc-project.
+/// Since then, they have been replaced by file system calls working with *.gemproj files
+///
+/// OK TO DELETE THIS FILE.
+/// But keeping it around just in case we need to re-instate graphQL
+
+/// MULTIPLE PROJECTS DATABASE QUERIES ////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** Loads the list of project names and ids from graphQL */
+async function m_LoadProjectNames() {
+  const response = await UR.Query(`
+    query {
+      projectNames { id label }
+    }
+  `);
+  if (!response.errors) {
+    if (DBG) console.log(...PR('m_LoadProjectNames response', response));
+    const { projectNames } = response.data;
+    const data = { projectNames }; // redundant, for clarification
+    UR.RaiseMessage('*:DC_PROJECTS_UPDATE', data);
+    return;
+  }
+  console.error(...PR('m_LoadProjectNames ERROR response:', response));
+}
+
+/// SINGLE PROJECT DATABASE QUERIES ///////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// PROJECT
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function m_LoadProjectFromDB(projId) {
+  console.log(...PR(`(1) LOAD PROJECT DATA ${projId}`));
+  const response = await UR.Query(`
+    query {
+      project(id:"${projId}") {
+        id
+        label
+        metadata { top right bottom left wrap bounce bgcolor roundsCanLoop}
+        rounds { id label time intro outtro initScript endScript }
+        blueprints { id label scriptText }
+        instances { id label bpid initScript }
+      }
+    }
+  `);
+  if (!response.errors) {
+    const { project } = response.data;
+    const data = { projId, project }; // redundant, for clarification
+    UR.RaiseMessage('*:DC_PROJECT_UPDATE', data);
+    return { ok: true };
+  }
+  console.error(...PR('m_LoadProjectNames ERROR response:', response));
+  return { ok: false, err: response };
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** return Promise to write to database
+ *  NOTE: Only updates project settings/metadata!!!  Rounds Blueprints, Instances are not updated.
+ */
+function promise_DBWriteProject(projId, project) {
+  const result = UR.Mutate(
+    `
+  mutation UpdateProject($projectId:String $input:ProjectInput) {
+    updateProject(projectId:$projectId,input:$input) {
+      id
+      label
+      metadata {
+        top
+        right
+        bottom
+        left
+        wrap
+        bounce
+        bgcolor
+        roundsCanLoop
+      }
+      rounds {
+        id
+        label
+        time
+        intro
+        outtro
+        initScript
+        endScript
+      }
+      blueprints {
+        id
+        label
+        scriptText
+      }
+      instances {
+        id
+        label
+        bpid
+        initScript
+      }
+    }
+  }`,
+    {
+      input: project,
+      projectId: projId
+    }
+  );
+  return result;
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** return Promise to write project settings (id, label, metdata) to database
+ *  NOTE: Only updates project settings/metadata!!!  Rounds Blueprints, Instances are not updated.
+ */
+function promise_WriteProjectSettings(projId, project) {
+  const result = UR.Mutate(
+    `
+  mutation UpdateProject($projectId:String $input:ProjectInput) {
+    updateProject(projectId:$projectId,input:$input) {
+      id
+      label
+      metadata {
+        top
+        right
+        bottom
+        left
+        wrap
+        bounce
+        bgcolor
+        roundsCanLoop
+      }
+    }
+  }`,
+    {
+      input: project,
+      projectId: projId
+    }
+  );
+  return result;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// METADATA
+// NOT USED CURRENTLY -- Project handles Metadata loading
+// async function m_LoadMetadata(projId) {
+//   if (DBG) console.log(...PR('(1) GET METADATA'));
+//   const response = await UR.Query(
+//     `
+//     query GeMetadata($id:String!) {
+//       project(id:$id) {
+//         metadata { top right bottom left wrap bounce bgcolor roundsCanLoop }
+//       }
+//     }
+//   `,
+//     { id: projId }
+//   );
+//   if (!response.errors) {
+//     const { metadata } = response.data;
+//     updateAndPublish(metadata);
+//   }
+// }
+/** return Promise to write metadata only (no id, label) to database */
+function promise_WriteMetadata(projId, metadata) {
+  return UR.Mutate(
+    `
+    mutation UpdateMetadata($projectId:String $input:ProjectMetaInput) {
+      updateMetadata(projectId:$projectId,input:$input) {
+        top
+        right
+        bottom
+        left
+        wrap
+        bounce
+        bgcolor
+        roundsCanLoop
+      }
+    }`,
+    {
+      input: metadata,
+      projectId: projId
+    }
+  );
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// ROUNDS
+// NOT USED CURRENTLY -- Project handles Rounds loading
+// async function m_LoadRounds(projId) {
+//   if (DBG) console.log(...PR('(1) GET ROUNDS DATA'));
+//   const response = await UR.Query(`
+//     query {
+//       project(id:"${projId}") {
+//         rounds { id label time intro outtro initScript endScript }
+//       }
+//     }
+//   `);
+//   if (!response.errors) {
+//     const { rounds } = response.data;
+//     updateAndPublish(rounds);
+//   }
+// }
+/** return Promise to write to database */
+async function promise_WriteRounds(projId, rounds) {
+  const result = await UR.Mutate(
+    `
+    mutation UpdateRounds($projectId:String $input:[ProjectRoundInput]) {
+      updateRounds(projectId:$projectId,input:$input) {
+        id
+        label
+        time
+        intro
+        outtro
+        initScript
+        endScript
+      }
+    }`,
+    {
+      input: rounds,
+      projectId: projId
+    }
+  );
+  return result;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// BLUEPRINTS
+// NOT USED CURRENTLY -- Project handles blueprint loading
+// async function m_LoadBlueprints(projId) {
+//   if (DBG) console.log(...PR('(1) GET ROUNDS DATA'));
+//   const response = await UR.Query(`
+//     query {
+//       project(id:"${projId}") {
+//         blueprints {
+//           id
+//           label
+//           scriptText
+//         }
+//       }
+//     }
+//   `);
+//   if (!response.errors) {
+//     const { blueprints } = response.data;
+//     updateAndPublish(projId, blueprints);
+//   }
+// }
+/** return Promise to write to database */
+function promise_WriteBlueprints(projId, blueprints) {
+  const result = UR.Mutate(
+    `
+    mutation UpdateBlueprints($projectId:String $input:[ProjectBlueprintInput]) {
+      updateBlueprints(projectId:$projectId,input:$input) {
+        id
+        label
+        scriptText
+      }
+    }`,
+    {
+      input: blueprints,
+      projectId: projId
+    }
+  );
+  return result;
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// INSTANCES
+// NOT USED CURRENTLY -- Project handles instances loading
+// async function m_LoadInstances(projId) {
+//   if (DBG) console.log(...PR('(1) GET INSTANCES DATA'));
+//   const response = await UR.Query(`
+//     query {
+//       project(id:"${projId}") {
+//         instances { id label bpid initScript }
+//       }
+//     }
+//   `);
+//   if (!response.errors) {
+//     const { instances } = response.data;
+//     updateAndPublish(instances);
+//   }
+// }
+/** return Promise to write to database */
+function promise_WriteInstances(projId, instances) {
+  const result = UR.Mutate(
+    `
+    mutation UpdateInstances($projectId:String $input:[ProjectInstanceInput]) {
+      updateInstances(projectId:$projectId,input:$input) {
+        id
+        label
+        bpid
+        initScript
+      }
+    }`,
+    {
+      input: instances,
+      projectId: projId
+    }
+  );
+  return result;
+}
+
+/// URSYS HANDLERS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+async function HandleLoadProject(data: { projId: string }) {
+  if (data === undefined || data.projId === undefined)
+    throw new Error(`${[...PR]} Called with bad projId: ${data}`);
+  return m_LoadProjectFromAsset(data.projId);
+}
+async function HandleWriteProject(data: { projId: string; project: any }) {
+  if (DBG) console.log('WRITE PROJECT', data);
+  FileWriteProject(data.projId, data.project);
+  return promise_DBWriteProject(data.projId, data.project);
+}
+/// Not used at the moment -- ac-projects calls DC_WRITE_PROJECT/HandlewriteProject
+async function HandleWriteProjectSettings(data: {
+  projId: string;
+  project: any;
+}) {
+  if (DBG) console.log('WRITE PROJECT SETTINGS', data);
+  return promise_WriteProjectSettings(data.projId, data.project);
+}
+async function HandleWriteMetadata(data: { projId: string; metadata: any[] }) {
+  if (DBG) console.log('WRITE ROUND', data);
+  return promise_WriteMetadata(data.projId, data.metadata);
+}
+async function HandleWriteRounds(data: { projId: string; rounds: any[] }) {
+  if (DBG) console.log('WRITE ROUND', data);
+  UpdateProjectFile(data.projId, data);
+  return promise_WriteRounds(data.projId, data.rounds);
+}
+async function HandleWriteBlueprints(data: {
+  projId: string;
+  blueprints: any[];
+}) {
+  if (DBG) console.log('WRITE BLUEPRINTS', data);
+  UpdateProjectFile(data.projId, data);
+  return promise_WriteBlueprints(data.projId, data.blueprints);
+}
+async function HandleWriteInstances(data: { projId: string; instances: any[] }) {
+  if (DBG) console.log('WRITE INSTANCES', data);
+  UpdateProjectFile(data.projId, data);
+  return promise_WriteInstances(data.projId, data.instances);
+}
+
+/// URSYS API /////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// Handle both LOCAL and NET requests.  ('*' is deprecated)
+UR.HandleMessage('LOCAL:DC_WRITE_PROJECT_SETTINGS', HandleWriteProjectSettings);
+UR.HandleMessage('LOCAL:DC_WRITE_METADATA', HandleWriteMetadata);
+
+/// PHASE MACHINE DIRECT INTERFACE ////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// for loading data structures
+UR.HookPhase(
+  'UR/LOAD_DB',
+  () =>
+    new Promise<void>((resolve, reject) => {
+      m_LoadProjectNames();
+      console.log(...PR('resolved LOAD_DB'));
+      resolve();
+    })
+);

--- a/gs_packages/gem-srv/src/modules/datacore/dc-project.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-project.ts
@@ -122,6 +122,15 @@ async function ProjectFileLoadFromAsset(projId: string): Promise<TProject> {
   return project;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API: Read project data from assets and broadcast loaded data to
+ *  ac-project.  Loads a simple string.  Conversion to TOML happens
+ *  in ac-projects.LoadProjectFromAsset */
+async function PreferencesFileLoadFromAsset(): Promise<string> {
+  const PREFERENCES_LOADER = ASSETS.GetLoader('preferences');
+  const preferences = await PREFERENCES_LOADER.getPreferences();
+  return preferences;
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** API: During Login, a user can elect to create a new project
  *  file out of existing template file.  PanelSelectSimulation
  *  calls this directly.  This will load the template file,
@@ -189,5 +198,6 @@ export {
 export {
   ProjectFileRequestWrite, // write to server
   ProjectFileLoadFromAsset, // load from server
+  PreferencesFileLoadFromAsset, //
   ProjectFileCreateFromTemplate //
 };

--- a/gs_packages/gem-srv/src/modules/sim/script/keywords/_comment.tsx
+++ b/gs_packages/gem-srv/src/modules/sim/script/keywords/_comment.tsx
@@ -17,7 +17,7 @@ import { RegisterKeyword } from 'modules/datacore';
 export class _comment extends Keyword {
   // base properties defined in KeywordDef
   constructor() {
-    super('_comment');
+    super('//'); // use '//' as the comment keyword (orig was '_comment')
     this.args = ['?:{...}'];
   }
 

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/class-gscript-tokenizer-v2.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/class-gscript-tokenizer-v2.ts
@@ -820,7 +820,7 @@ function KeywordFromToken(kwTok: any): string {
   const fn = 'KeywordFromToken:';
   const [type, value] = UnpackToken(kwTok);
   if (type === 'directive') return '_directive';
-  if (type === 'comment') return '_comment';
+  if (type === 'comment') return '//'; // use '//' instead of '_comment'
   if (type === 'line') return '_line';
   if (type !== 'identifier') {
     console.log(`${fn} bad token`, kwTok);

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
@@ -1,0 +1,52 @@
+/*  Comment Utilities
+
+    What it does:
+    * Manages
+      * explanation comments
+      * change comments
+
+    * Provides data stuctures for style definitions in the project files
+      (where to store them)
+
+    * Provides a hard coded css comment detection code to be used by
+        SharedElements.GToken
+      to set the comment type for fancy formating, e.g. "explanation comments".
+
+    * Provides methods, if needed, to add and remove style definitions
+      to the projects file.
+
+    * Generates bookmarks at compile time with line numbers so it's accessible to
+      UI elements via the bundle (e.g. symbols).
+
+    * Reference code to look at:
+      -- `t-script.d.ts.TBundleSymbols:314`
+      -- Also see `class-symbol-interpreter` for how to reference bundle symbol data.
+         but this is not where we want to place it.  (How would we provide
+         support to UI, the structures for visual rendering)
+
+    Derived data source from the bundle symbol table.
+    We would create a new type of symbol table for supporting comment bookmarks.
+
+    Next step: physical connections to the model -- stub API methods
+
+
+*/
+
+function GetClasses(type: string, label: string): string {
+  let classes: string;
+  if (type === '{noncode}') {
+    classes = ' styleComment';
+    if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
+    if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
+    if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
+    if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
+    if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
+    if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
+    if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
+    if (label.includes('🔎')) classes += ' explanationCommentBody';
+    if (label.includes('✏️')) classes += ' changeCommentBody';
+  }
+  return classes;
+}
+
+export { GetClasses };

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
@@ -37,14 +37,16 @@
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// These are defined in gem-ui.css
 const COMMENTTYPEMAP = new Map<string, any>();
-COMMENTTYPEMAP.set('COMMENT KEY', {
-  cssClass: 'commentKeyHeader',
-  help: '',
-  isBookmark: false
-});
+
 COMMENTTYPEMAP.set('🔎 WHAT', {
   cssClass: 'explanationCommentHeader',
   help: 'Explanation of how this code works',
+  isBookmark: false
+});
+
+COMMENTTYPEMAP.set('🔎', {
+  cssClass: 'explanationCommentBody',
+  help: 'Additional explanations of how something works',
   isBookmark: false
 });
 
@@ -53,14 +55,10 @@ COMMENTTYPEMAP.set('✏️ CHANGE', {
   help: 'Code that should be changed by a student',
   isBookmark: true
 });
-COMMENTTYPEMAP.set('🔎', {
-  cssClass: 'explanationCommentBody',
-  help: '',
-  isBookmark: false
-});
+
 COMMENTTYPEMAP.set('✏️', {
   cssClass: 'changeCommentBody',
-  help: '',
+  help: 'Additional details of what a student might change',
   isBookmark: false
 });
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
@@ -1,4 +1,8 @@
-/*  Comment Utilities
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+    Comment Utilities
+
+    Utilities for styling and bookmarking comments in gemscript wizard code.
 
     What it does:
     * Manages
@@ -27,26 +31,129 @@
     Derived data source from the bundle symbol table.
     We would create a new type of symbol table for supporting comment bookmarks.
 
-    Next step: physical connections to the model -- stub API methods
+    Next Steps:
+    * Figure out how introduce AddStyles to add to project settings
 
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
-*/
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// These are defined in gem-ui.css
+const COMMENTTYPEMAP = new Map<string, any>();
+COMMENTTYPEMAP.set('COMMENT KEY', {
+  style: 'commentKeyHeader',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('🔎 WHAT', {
+  style: 'explanationCommentHeader',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('🔎 DEFINITION', {
+  style: 'explanationCommentHeader',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('🔎 QUESTION', {
+  style: 'explanationCommentHeader',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('✏️ LETS', {
+  style: 'changeCommentHeader',
+  isBookmark: true
+});
+COMMENTTYPEMAP.set('✏️ CHANGE', {
+  style: 'changeCommentHeader',
+  isBookmark: true
+});
+COMMENTTYPEMAP.set('✏️ HYPOTHESIS', {
+  style: 'changeCommentHeader',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('🔎', {
+  style: 'explanationCommentBody',
+  isBookmark: false
+});
+COMMENTTYPEMAP.set('✏️', {
+  style: 'changeCommentBody',
+  isBookmark: false
+});
 
+/// STYLE INTERFACE ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** AddStyle
+ *  @param {string} matchString
+ *  @param {string} cssStyle
+ *  @param {boolean} isBookmark
+ */
+function AddStyle(matchString: string, cssStyle: string, isBookmark: boolean) {
+  // Check for existence before styleMap
+  if (COMMENTTYPEMAP.has(matchString))
+    console.warn(`Style ${matchString} already defined ${cssStyle}`);
+  COMMENTTYPEMAP.set(matchString, { style: cssStyle, isBookmark });
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function DeleteStyle() {}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** GetClasses -- used in SharedElements.GToken()
+ *  @param {string} type
+ *  @param {string} label
+ *  @return {string}
+ */
 function GetClasses(type: string, label: string): string {
   let classes: string;
   if (type === '{noncode}') {
     classes = ' styleComment';
-    if (label.includes('COMMENT KEY')) classes += ' commentKeyHeader';
-    if (label.includes('🔎 WHAT')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 DEFINITION')) classes += ' explanationCommentHeader';
-    if (label.includes('🔎 QUESTION')) classes += ' explanationCommentHeader';
-    if (label.includes('✏️ LETS')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ CHANGE')) classes += ' changeCommentHeader';
-    if (label.includes('✏️ HYPOTHESIS')) classes += ' changeCommentHeader';
-    if (label.includes('🔎')) classes += ' explanationCommentBody';
-    if (label.includes('✏️')) classes += ' changeCommentBody';
+    COMMENTTYPEMAP.forEach((value, key) => {
+      if (label.includes(key)) classes += ` ${value.style}`;
+    });
   }
   return classes;
 }
 
-export { GetClasses };
+/// BOOKMARK INTERFACE ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// During compile/render, we'll iterate through the lines and construct the
+/// list of bookmarks
+const BOOKMARKS = [];
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function m_GetBookmarkFromScriptLine(line: any) {
+  const { vmTokens, lineNum } = line;
+  const { scriptToken } = vmTokens[0] || {};
+  const { comment } = scriptToken || {};
+  const matchedStyles = [...COMMENTTYPEMAP.keys()];
+  let styleName = '';
+  let isBookmark = false;
+  const u_scanstyles = text => {
+    const match = matchedStyles.find(
+      matchedStyle => text !== undefined && text.includes(matchedStyle)
+    );
+    if (match) {
+      styleName = COMMENTTYPEMAP.get(match).style;
+      isBookmark = COMMENTTYPEMAP.get(match).isBookmark;
+    }
+  };
+  u_scanstyles(comment);
+  if (comment && isBookmark) {
+    BOOKMARKS.push({ lineNum: lineNum, comment, styleName });
+  }
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function MakeBookmarkViewData(script_page): any {
+  BOOKMARKS.splice(0, BOOKMARKS.length); // clear BOOKMARKS
+  script_page.forEach(line => m_GetBookmarkFromScriptLine(line));
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetBookmarkViewData(): any {
+  return BOOKMARKS;
+}
+
+/// MODULE EXPORTS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export {
+  // STYLES INTERFACE
+  AddStyle,
+  DeleteStyle,
+  GetClasses,
+  // BOOKMARKS INTERFACE
+  MakeBookmarkViewData,
+  GetBookmarkViewData
+};

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts
@@ -76,6 +76,17 @@ COMMENTTYPEMAP.set('✏️', {
   style: 'changeCommentBody',
   isBookmark: false
 });
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/**
+ * @return {Array} [ ...{cssClass, label}]
+ */
+function GetCommentStyles() {
+  const styles = [];
+  COMMENTTYPEMAP.forEach((val, key) => {
+    styles.push({ key, cssStyle: val.style });
+  });
+  return styles;
+}
 
 /// STYLE INTERFACE ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -149,7 +160,9 @@ function GetBookmarkViewData(): any {
 /// MODULE EXPORTS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 export {
+  COMMENTTYPEMAP,
   // STYLES INTERFACE
+  GetCommentStyles,
   AddStyle,
   DeleteStyle,
   GetClasses,

--- a/gs_packages/gem-srv/src/modules/sim/script/tools/script-compiler.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/script-compiler.ts
@@ -101,7 +101,9 @@ function DecodeStatement(
   const dUnit: TScriptUnit = statement.map((tok, line) => {
     if (line === 0) {
       const arg = DecodeToken(tok, refs);
-      if (typeof arg === 'object' && arg.comment) return '_comment';
+      // convert '_comment' to '//'
+      // if (typeof arg === 'object' && arg.comment) return '_comment';
+      if (typeof arg === 'object' && arg.comment) return '//';
       return arg;
     }
     return DecodeToken(tok, refs);

--- a/gs_packages/gem-srv/src/test/gemscript/gui-wizard-slots-orig.gemscript
+++ b/gs_packages/gem-srv/src/test/gemscript/gui-wizard-slots-orig.gemscript
@@ -1,0 +1,45 @@
+# blueprint GuiWizardSlots
+
+// orig full text version 
+// but this won't load in current branch
+
+# TAG isCharControllable false
+# PROGRAM DEFINE
+useFeature Costume
+addProp energyType String 'producer'
+addProp energyLevel number 50
+
+# program init
+prop energyLevel setTo 0
+prop agent.energyLevel setTo 0
+prop energyLevel setTo 'foo'
+prop energyLevel
+prop
+prop x
+prop x setTo
+prop x setTo 400
+prop x setTo 400 'too' 'many' 'parms'
+prop energyType setMin
+prop energyType setTo
+prop energyType setTo 'help'
+prop unknownPropName setTo 400
+prop x badMethod 400
+prop x setTo 'wrongType'
+prop agent.x setTo
+prop Costume.costumeName
+prop x setToRnd -400 400 true
+prop y setTo -400
+
+# ProgRam ConDition
+when Boo centerFirstTouches Boo [[
+  prop Boo.energyType add 1
+]]
+
+# PROGRAM Update
+every 1 runAtStart [[
+  if {{ energyLevel > 1 }} [[
+    prop energyLevel sub 1
+  ]] [[
+    prop energyLevel setTo 50
+  ]]
+]]

--- a/gs_packages/gem-srv/src/types/t-assets.d.ts
+++ b/gs_packages/gem-srv/src/types/t-assets.d.ts
@@ -19,7 +19,7 @@ declare global {
   type TAssetId = number;
   type TAssetName = string;
   type TAssetURL = string;
-  type TAssetType = 'sprites' | 'sounds' | 'projects';
+  type TAssetType = 'sprites' | 'sounds' | 'projects' | 'preferences';
   type TManifest = { [K in TAssetType]?: TAssetDef[] };
 
   /// PUBLIC API FOR ASSET LOADER SUBCLASSERS ///////////////////////////////////
@@ -82,6 +82,11 @@ declare global {
     label: string;
     bpid: string;
     initScript: string;
+  };
+  /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  /** project preferences */
+  type TPreferences = {
+    commentTypes: [any];
   };
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** used to map blueprint name to blueprint instance definitions */

--- a/gs_packages/ursys/src/common/ur-constants.js
+++ b/gs_packages/ursys/src/common/ur-constants.js
@@ -43,9 +43,10 @@ const VALID_CHANNELS = ['LOCAL', 'NET', 'SVR', 'STATE']; // is all channels in l
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const VALID_ASSET_EXTS = {
   sprites: ['.png', '.gif', '.jpg', '.jpeg', '.json'],
-  projects: ['.gemprj']
+  projects: ['.gemprj'],
+  preferences: ['.toml', '.yaml'] // yaml can be supported but is not implemented
 };
-const VALID_ASSET_DIRS = ['sprites', 'projects']; // valid asset subdirectories
+const VALID_ASSET_DIRS = ['sprites', 'projects', 'preferences']; // valid asset subdirectories
 
 /// EXPORTS ///////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/ursys/src/util/manifest.js
+++ b/gs_packages/ursys/src/util/manifest.js
@@ -68,7 +68,7 @@ function f_SpriteAssets(subdirpath, files) {
   return { mediafiles: imgFiles };
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/** filter the filelist for valid sprite-related image files */
+/** filter the filelist for valid gem project files */
 function f_ProjectAssets(subdirpath, files) {
   // scan for project files in assets
   const jsfiles = files.filter(f => Path.extname(f).toLowerCase() === '.gemprj');
@@ -76,6 +76,16 @@ function f_ProjectAssets(subdirpath, files) {
     TERM(`... jsfiles contained ${jsfiles.length} project references`);
   }
   return { mediafiles: jsfiles };
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** filter the filelist for valid TOML preferences files */
+function f_PreferencesAssets(subdirpath, files) {
+  // scan for toml files in assets
+  const tomlfiles = files.filter(f => Path.extname(f).toLowerCase() === '.toml');
+  if (DBG) {
+    TERM(`... jsfiles contained ${tomlfiles.length} preferences references`);
+  }
+  return { mediafiles: tomlfiles };
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Return a list of mediafiles for the assetype of the directory, which is
@@ -100,6 +110,10 @@ function m_ScanAssets(subdirpath) {
       case 'projects':
         mediaObj = f_ProjectAssets(subdirpath, files);
         if (DBG) TERM(`project scanAssets mediaObj ${JSON.stringify(mediaObj)}`);
+        break;
+      case 'preferences':
+        mediaObj = f_PreferencesAssets(subdirpath, files);
+        if (DBG) TERM(`preferences scanAssets mediaObj ${JSON.stringify(mediaObj)}`);
         break;
       default:
         mediaObj = { err: `unknown astype ${asType}` };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,6 +2181,11 @@
 				"warning": "^4.0.3"
 			}
 		},
+		"@iarna/toml": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+		},
 		"@istanbuljs/schema": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",


### PR DESCRIPTION
# Overview

This adds a number of comment-related features to the system.

## Comment Styles

Added a new preferences system to define comment styles.  There are three pieces to this:

### 1. Preferences Loader
* We added a new asset loader that can read any `.TOML` file in the preferences folder.
* Currently the only preferences file that is supported is `_comment_types.toml`, but other preferences can be easily added.
* Preferences are saved in the art assets folder under each site's `preferences` folder, e.g. in `/gsgo/gs_assets/art-assets/preferences/_comment_types.toml` -- this hasn't been committed to the `art-assets` repo yet.
* The preferences system can readily add other `.TOML` and `.YAML` file assets.  (`.YAML` support is available but not implemented yet)

### 2. Defining Comment Styles
* New Comment Types can be defined using the new `preferences/_comment_types.toml` file.
* See the `_comment_types.toml` file for examples.   (attached as a .txt file for ease of reading)
[_comment_types.toml.txt](https://github.com/theRAPTLab/gsgo/files/12502107/_comment_types.toml.txt)
* Comment Types in preferences files will override built-in comment types (the console will display a warning that a comment type was previously defined).
* `color` and `backgroundColor` can be defined for each comment type.

#### _comment_types.toml help text
```
# PREFERENCES
#
#   Preferences are site-wide settings that apply to all projets.
#
#   Current Preferences support:
#     * Comment Types
#
# Comment Types
#   Comment Types are used to define the visual display of comments
#   in the ScriptEditor views.  You can define:
#     * `matchString` -- the search string used to set the visual style
#     * `cssClass` -- use a pre-defined css class (from `gem-ui.css`)
#     * `color` / `backgroundColor` -- css colors to use inplace of cssClasses
#     * `help` -- Short help blurb to display in the comment edit pane
#     * `isBookmark` -- flag to mark the comment type as a bookmark, 
#                       selectable from the ScriptEditor script lines view
#
#   To set the comment colors, use either:
#     A.`cssClass` to one of the predefined styles, or...
#        - commentKeyHeader
#        - explanationCommentHeader
#        - explanationCommentBody
#        - changeCommentHeader
#        - changeCommentBody
#     B. 'color' and/or 'backgroundColor' to override the color
#        You can use either 'color', or 'backgroundColor' or both.
#        Any colors defined will override the cssClass style.
#        Colors are defined as css values.  You can use:
#        * hexadecimal "#rgb" "#rrggbb", e.g. "#f00" for red
#        * rgb alpha "rgba(r,g,b,a)", e.g. "rgba(255,0,0,0.5)" for a transparent red
# 
#   You can override existing styles by adding them by using the
#   same `matchString` in the COMMENTTYPEMAP defined in
#   `gs_packages/gem-srv/src/modules/sim/script/tools/comment-utilities.ts`
```

### 3. Inputting Comment Text and Using Comment Styles

Comment lines can now be selected and edited via the wizard.  In addition, you can now select a comment style via a popup selection menu and the full comment line will be automatically generated.
* Styles are optional.  To select a comment without a style, leave the menu selection "empty" with "-- no style --".
* Select a style from the popup menu to automatically change the comment text to include the style snippet.
* Add comment text to the input field as you would with any GEMSCRIPT code

Technical Background: GEMSCRIPT scripts are text lines that are parsed and converted into tokens corresponding to keywords and parameters for each line of script.  The input UI system uses an elaborate system of components to convert the keywords and parameters into the wizard UI.  Comments however are not strictly speaking keywords.  In order to provide a wizard UI for comments, we construct a secondary UI that handles the destructuring of comment text into prefix styles and comment body text so that they can be independently edited, and the reconstructed into a single comment line.  See cf91c683ee19c30fc640a8b8a904135ab1de5069.

![screenshot_1306](https://github.com/theRAPTLab/gsgo/assets/1403057/be2d4ba4-a118-47ef-8ffd-9805dbd75668)


## Bookmarks

Bookmarks can be added to GEMSCRIPT code. When opening a script, users can select a bookmark from a list of bookmarks and automatically scroll to the selected line and enable editing for the line.

* Bookmarks are defined by designating a particular match string as a bookmark.  Any comment that matches the matchstring will automatically create a bookmark.
* Bookmarks listed and selected via a SELECTION menu.

![screenshot_1300](https://github.com/theRAPTLab/gsgo/assets/1403057/fdc644dd-0c89-4ca0-9537-535bca6624b9)


Addresses #751, #758


# To Do
* [x] Add bookmarks
* [x] Support custom comment style definitions
   * [x] Figure out how to define styles: use css classes or custom color settings?
   * [x] Save styles in a single `art-assets` settings file (See #758)
  