### PR TITLE
Gracefully fail if blueprint name is changed

### DIFF
--- a/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/tools/class-symbol-interpreter.ts
@@ -1131,8 +1131,8 @@ class SymbolInterpreter {
     const goodBlueprint =
       bpName === 'agent' || SIMDATA.HasBlueprintBundle(bpName);
     // Part 2 should be valid propName
-    const prop = props[propName];
-    const goodProp = props[propName] !== undefined;
+    const prop = props ? props[propName] : undefined;
+    const goodProp = props ? props[propName] !== undefined : undefined;
     if (goodBlueprint && goodProp) {
       // Found a goodProp, so add the prop methods to the cur_scope
       // so that the next slot (methodName) knows which methods are


### PR DESCRIPTION
Changing the bpName resulted in an undefined object.  This catches the error so editing can continue.
Addresses #767