### PR TITLE
WIP Feature: Select Character Type for pozyx tags

### DIFF
--- a/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
@@ -22,7 +22,7 @@ class PanelMap extends React.Component {
     this.state = {
       title: 'CHARACTER CONTROLLERS',
       simulationName: 'Aquatic Ecosystems',
-      bpNamesList: [],
+      pozyxControlBpNames: [],
       tags: []
     };
     this.urBlueprintsStateUpdated = this.urBlueprintsStateUpdated.bind(this);
@@ -36,10 +36,9 @@ class PanelMap extends React.Component {
   }
 
   urBlueprintsStateUpdated(stateObj, cb) {
-    const { nonGlobalBpNamesList } = stateObj;
-    if (nonGlobalBpNamesList) {
-      // 'global' should not be selectable as a bp on PanelMaps
-      this.setState({ bpNamesList: nonGlobalBpNamesList });
+    const { pozyxControlBpNames } = stateObj;
+    if (pozyxControlBpNames) {
+      this.setState({ pozyxControlBpNames });
     }
     if (typeof cb === 'function') cb();
   }
@@ -50,7 +49,6 @@ class PanelMap extends React.Component {
   urInstancesStateUpdated(stateObj, cb) {
     const { instances, tags } = stateObj;
     if (tags) this.setState({ tags });
-
     if (typeof cb === 'function') cb();
   }
 
@@ -62,9 +60,9 @@ class PanelMap extends React.Component {
   }
 
   render() {
-    const { title, simulationName, bpNamesList, tags } = this.state;
+    const { title, simulationName, pozyxControlBpNames, tags } = this.state;
     const { id, devices, isMinimized, onClick, classes } = this.props;
-    if (!bpNamesList) return ''; // not loaded yet
+    if (!pozyxControlBpNames) return ''; // not loaded yet
 
     // STYLES - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     const styleDeviceConnector = {
@@ -193,7 +191,7 @@ class PanelMap extends React.Component {
           style={{ minHeight: '25px', fontSize: '12px' }}
           onChange={event => this.HandleTagSelect(event, t.id)}
         >
-          {bpNamesList.map(b => (
+          {pozyxControlBpNames.map(b => (
             <option key={b} value={b}>
               {b}
             </option>

--- a/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import UR from '@gemstep/ursys/client';
-import * as ACBlueprints from 'modules/appcore/ac-blueprints';
 import * as ACInstances from 'modules/appcore/ac-instances';
 import { withStyles } from '@material-ui/core/styles';
 import { useStylesHOC } from '../helpers/page-xui-styles';
@@ -27,12 +26,14 @@ class PanelMap extends React.Component {
     };
     this.urBlueprintsStateUpdated = this.urBlueprintsStateUpdated.bind(this);
     this.urInstancesStateUpdated = this.urInstancesStateUpdated.bind(this);
+    this.UpdateTags = this.UpdateTags.bind(this);
     this.HandleTagSelect = this.HandleTagSelect.bind(this);
   }
 
   componentDidMount() {
     UR.SubscribeState('blueprints', this.urBlueprintsStateUpdated);
     UR.SubscribeState('instances', this.urInstancesStateUpdated);
+    this.UpdateTags(ACInstances.GetTags()); // force update after Map Save
   }
 
   urBlueprintsStateUpdated(stateObj, cb) {
@@ -48,8 +49,12 @@ class PanelMap extends React.Component {
   // * intance group `tags` are dynamically generated instances like charcontrol and pozyx
   urInstancesStateUpdated(stateObj, cb) {
     const { instances, tags } = stateObj;
-    if (tags) this.setState({ tags });
+    this.UpdateTags(tags);
     if (typeof cb === 'function') cb();
+  }
+
+  UpdateTags(tags) {
+    if (tags) this.setState({ tags });
   }
 
   // User has selected a new blueprint to map to the selected input tag

--- a/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import UR from '@gemstep/ursys/client';
 import * as ACBlueprints from 'modules/appcore/ac-blueprints';
+import * as ACInstances from 'modules/appcore/ac-instances';
 import { withStyles } from '@material-ui/core/styles';
 import { useStylesHOC } from '../helpers/page-xui-styles';
 
@@ -60,10 +61,11 @@ class PanelMap extends React.Component {
     if (typeof cb === 'function') cb();
   }
 
-  // User has selected a new blueprint to map to the selecetd pozyx tag
+  // User has selected a new blueprint to map to the selected input tag
   // Create a new instance with the selected blueprint
   HandleTagSelect(event, inputID) {
-    ACBlueprints.RegisterInputBp(inputID, event.target.value);
+    const bpName = event.target.value;
+    ACInstances.UpdateTag(inputID, bpName);
   }
 
   render() {

--- a/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
@@ -49,15 +49,8 @@ class PanelMap extends React.Component {
   // * intance group `tags` are dynamically generated instances like charcontrol and pozyx
   urInstancesStateUpdated(stateObj, cb) {
     const { instances, tags } = stateObj;
-    if (tags) {
-      // assign instances to default bp by default
-      const defaultBpName = ACBlueprints.GetDefaultInputBpName();
-      const defaultTags = tags.map(t => {
-        t.bpid = defaultBpName;
-        return t;
-      });
-      this.setState({ tags: defaultTags });
-    }
+    if (tags) this.setState({ tags });
+
     if (typeof cb === 'function') cb();
   }
 

--- a/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelMap.jsx
@@ -86,29 +86,41 @@ class PanelMap extends React.Component {
     ];
 
     // JSX CONSTRUCTORS - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    const scriptEditorsJSX = scriptEditors.map(e => (
-      <div style={styleDeviceContainer} key={e.uaddr}>
-        <hr style={styleDeviceConnector} />
-        <div style={styleDeviceLeft} className={classes.filledOutline}>
-          <div className={classLabel}>{e.uaddr}:</div>
-          <div className={classData}>{e.name}</div>
-          <div className={classLabel}>Script:</div>
-          <div className={classData}>{e.script}</div>
-        </div>
-      </div>
-    ));
-    const controllersJSX = controllers.map(e => (
-      <div style={styleDeviceContainer} key={e.uaddr}>
-        <hr style={styleDeviceConnector} />
-        <div style={styleDeviceRight} className={classes.filledOutline}>
-          <div className={classLabel}>{e.uaddr}:</div>
-          <div className={classData}>{e.name}</div>
-          <div className={classLabel}>Control:</div>
-          <div className={classData}>{e.instance}</div>
-        </div>
-      </div>
-    ));
-    const observersJSX = observers.map(e => (
+
+    // OLD Development Code Demo
+    // const scriptEditorsJSX = scriptEditors.map(e => (
+    //   <div style={styleDeviceContainer} key={e.uaddr}>
+    //     <hr style={styleDeviceConnector} />
+    //     <div style={styleDeviceLeft} className={classes.filledOutline}>
+    //       <div className={classLabel}>{e.uaddr}:</div>
+    //       <div className={classData}>{e.name}</div>
+    //       <div className={classLabel}>Script:</div>
+    //       <div className={classData}>{e.script}</div>
+    //     </div>
+    //   </div>
+    // ));
+    // const controllersJSX = controllers.map(e => (
+    //   <div style={styleDeviceContainer} key={e.uaddr}>
+    //     <hr style={styleDeviceConnector} />
+    //     <div style={styleDeviceRight} className={classes.filledOutline}>
+    //       <div className={classLabel}>{e.uaddr}:</div>
+    //       <div className={classData}>{e.name}</div>
+    //       <div className={classLabel}>Control:</div>
+    //       <div className={classData}>{e.instance}</div>
+    //     </div>
+    //   </div>
+    // ));
+    // const observersJSX = observers.map(e => (
+    //   <div
+    //     style={styleDeviceCenter}
+    //     className={classes.filledOutline}
+    //     key={e.uaddr}
+    //   >
+    //     <div className={classLabel}>{e.uaddr}:</div>
+    //     <div className={classData}>{e.name}</div>
+    //     <div className={classLabel}>Observing</div>
+    //   </div>
+    // ));
       <div
         style={styleDeviceCenter}
         className={classes.filledOutline}

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -86,6 +86,8 @@ STATE.initializeState({
   bpDefs: [], // [{name, scriptText},...] raw blueprint script text used for saving to gemproj file
   // runtime states derived from bpDefs or bpBundles
   bpNamesList: [],
+  nonGlobalBpNamesList: [], // used for populating selection menus that exclude 'global'
+  defaultBpName: '', // derived from bpNamesList, used as fallback
   defaultPozyxBpid: '',
   charControlBpNames: [],
   ptrackControlBpNames: [],
@@ -359,14 +361,24 @@ function m_UpdateAndPublishDerivedBpLists() {
   const charControlBpNames = m_GenerateCharControlBpNames(bundles);
   const ptrackControlBpNames = m_GeneratePTrackControlBpNames(bundles);
   const pozyxControlBpNames = m_GeneratePozyxControlBpNames(bundles);
+
+  // Derive Default BPName, excluding 'global'
+  const nonGlobalBpNamesList = bpNamesList.filter(b => b !== GLOBAL_AGENT_NAME);
+  const defaultBpName =
+    nonGlobalBpNamesList.length > 0 ? nonGlobalBpNamesList[0] : undefined;
+
   STATE.updateKey({
     bpNamesList,
+    nonGlobalBpNamesList,
+    defaultBpName,
     charControlBpNames,
     ptrackControlBpNames,
     pozyxControlBpNames
   });
   STATE._publishState({
     bpNamesList,
+    nonGlobalBpNamesList,
+    defaultBpName,
     charControlBpNames,
     ptrackControlBpNames,
     pozyxControlBpNames

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -68,6 +68,7 @@ import * as DCPROJECT from 'modules/datacore/dc-project';
 import * as SIMAGENTS from 'modules/sim/sim-agents';
 import * as TRANSPILER from '../sim/script/transpiler-v2';
 import { DEBUG_FLAGS } from 'config/dev-settings';
+import { TYPES } from '../step/lib/class-ptrack-endpoint';
 const { SYMBOLIZE_CALLS: DBG_SC } = DEBUG_FLAGS;
 import ERROR from 'modules/error-mgr';
 
@@ -243,6 +244,22 @@ function GetBpNamesList(): string[] {
   return STATE._getKey('bpNamesList');
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetDefaultInputBpName(type: string): string {
+  switch (type) {
+    case TYPES.Pozyx:
+      return GetPozyxControlDefaultBpName();
+    case TYPES.Object:
+      return GetPTrackControlDefaultBpName();
+    case TYPES.People:
+      return GetPTrackControlDefaultBpName();
+    case TYPES.Pose:
+      return GetPTrackControlDefaultBpName();
+    default:
+      // TYPES.Faketrack adds a suffix to the type, e.g. `ft-f`
+      return STATE._getKey('defaultBpName');
+  }
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Generates an array of blueprint names that have been tagged
  *  as CharControllable by inspecting the bundle.
  *  Used to populate agent selection on charController.
@@ -290,7 +307,13 @@ function GetPTrackControlBpNames(): string[] {
  */
 function GetPTrackControlDefaultBpName(): string {
   const ptrackBpNames = STATE._getKey('ptrackControlBpNames');
-  if (ptrackBpNames.length < 1) return undefined;
+  if (ptrackBpNames.length < 1) {
+    const defaultBpName = STATE._getKey('defaultBpName');
+    console.warn(
+      `ACBlueprints.GetPTrackControlDefaultBpName: No controllable PTrack blueprints have been defined!!! Defaulting to ${defaultBpName}.`
+    );
+    return defaultBpName;
+  }
   return ptrackBpNames[0];
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -318,7 +341,14 @@ function GetPozyxControlBpNames(): string[] {
  */
 function GetPozyxControlDefaultBpName(): string {
   const pozyxBpNames = STATE._getKey('pozyxControlBpNames');
-  if (pozyxBpNames.length < 1) return undefined;
+  console.error('GetPozyxControlDefaultBpName');
+  if (pozyxBpNames.length < 1) {
+    const defaultBpName = STATE._getKey('defaultBpName');
+    console.warn(
+      `ACBlueprints.GetPozyxControlDefaultBpName: No controllable Pozyx blueprints have been defined!!! Defaulting to ${defaultBpName}.`
+    );
+    return defaultBpName;
+  }
   // pick a random blueprint out of all the blueprints that have pozyx enabled
   const i = Math.round((pozyxBpNames.length - 1) * Math.random());
   return pozyxBpNames[i];

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
@@ -310,7 +311,7 @@ function GetPTrackControlDefaultBpName(): string {
   if (ptrackBpNames.length < 1) {
     const defaultBpName = STATE._getKey('defaultBpName');
     console.warn(
-      `ACBlueprints.GetPTrackControlDefaultBpName: No controllable PTrack blueprints have been defined!!! Defaulting to ${defaultBpName}.`
+      `ACBlueprints.GetPTrackControlDefaultBpName: No controllable PTrack blueprints have been defined!!! Defaulting to "${defaultBpName}".`
     );
     return defaultBpName;
   }
@@ -341,11 +342,10 @@ function GetPozyxControlBpNames(): string[] {
  */
 function GetPozyxControlDefaultBpName(): string {
   const pozyxBpNames = STATE._getKey('pozyxControlBpNames');
-  console.error('GetPozyxControlDefaultBpName');
   if (pozyxBpNames.length < 1) {
     const defaultBpName = STATE._getKey('defaultBpName');
     console.warn(
-      `ACBlueprints.GetPozyxControlDefaultBpName: No controllable Pozyx blueprints have been defined!!! Defaulting to ${defaultBpName}.`
+      `ACBlueprints.GetPozyxControlDefaultBpName: No controllable Pozyx blueprints have been defined!!! Defaulting to "${defaultBpName}".`
     );
     return defaultBpName;
   }
@@ -607,6 +607,7 @@ export {
   // Derived Blueprint Lists
   GetBpEditList, // used by ScriptEditor to display list of bp to edit
   GetBpNamesList,
+  GetDefaultInputBpName,
   GetCharControlBpNames,
   GetPTrackControlBpNames,
   GetPTrackControlDefaultBpName,
@@ -614,7 +615,6 @@ export {
   GetPozyxControlDefaultBpName,
   GetBlueprintProperties,
   GetBlueprintPropertiesMap,
-  // Updaters
   SetBlueprints,
   InjectBlueprint,
   UpdateBlueprint,

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -314,8 +314,14 @@ function GetPTrackControlDefaultBpName(): string {
       `ACBlueprints.GetPTrackControlDefaultBpName: No controllable PTrack blueprints have been defined!!! Defaulting to "${defaultBpName}".`
     );
     return defaultBpName;
+  } else if (ptrackBpNames.length === 1) {
+    // if there's only one, use that one
+    return ptrackBpNames[0];
+  } else {
+    // pick a random blueprint out of all the blueprints that have PTrack enabled
+    const i = Math.round((ptrackBpNames.length - 1) * Math.random());
+    return ptrackBpNames[i];
   }
-  return ptrackBpNames[0];
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Generates an array of blueprint names that have been tagged
@@ -348,10 +354,14 @@ function GetPozyxControlDefaultBpName(): string {
       `ACBlueprints.GetPozyxControlDefaultBpName: No controllable Pozyx blueprints have been defined!!! Defaulting to "${defaultBpName}".`
     );
     return defaultBpName;
+  } else if (pozyxBpNames.length === 1) {
+    // if there's only one, use that one
+    return pozyxBpNames[0];
+  } else {
+    // pick a random blueprint out of all the blueprints that have pozyx enabled
+    const i = Math.round((pozyxBpNames.length - 1) * Math.random());
+    return pozyxBpNames[i];
   }
-  // pick a random blueprint out of all the blueprints that have pozyx enabled
-  const i = Math.round((pozyxBpNames.length - 1) * Math.random());
-  return pozyxBpNames[i];
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** API: Returns array of properties {name, type, defaultvalue, isFeatProp}

--- a/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
@@ -29,10 +29,13 @@ STATE.initializeState({
     }
   ],
   instanceidList: [],
+  // currentInstance is the instance currently being edited it should be undefined by default
   currentInstance: undefined,
-  tags: []
-  // currentInstance is the instance currently being edited
-  // it should be undefined by default
+  // list of input sources: pozyx, ptrack, faketrack
+  // Used by PanelMap to show the list of available inputs
+  // constructed by dc-inputs during input phase see InputUpdateEntityTracks
+  tags: [] // inputDefs {bpid, id, lable, x, y, ...}
+
   //
   // Uncomment to debug
   // currentInstance: {
@@ -111,6 +114,33 @@ function EditInstance(id) {
   const instance = GetInstance(id);
   updateKey({ currentInstance: instance });
   _publishState({ currentInstance: instance });
+}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function UpdateTag(inputId: string, bpName: string) {
+  const tags = STATE._getKey('tags');
+  const index = tags.findIndex(t => t.id === inputId);
+  const updatedTag = tags[index];
+  if (updatedTag === undefined)
+    throw new Error(
+      `UpdateTag inputId not found ${inputId} in tags: ${JSON.stringify(
+        tags
+      )}.  This shouldn't happen!`
+    );
+  updatedTag.bpid = bpName;
+  tags.splice(index, 1, updatedTag);
+  STATE.updateKey({ tags });
+  // STATE._publishState({ tags });
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetTag(inputId: string) {
+  const tags = STATE._getKey('tags');
+  return tags.find(t => t.id === inputId);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetTagBpid(inputId: string) {
+  const tag = GetTag(inputId);
+  return tag ? tag.bpid : undefined;
 }
 
 /// LOADER ////////////////////////////////////////////////////////////////////
@@ -290,6 +320,10 @@ export {
   GetInstanceUID,
   // InstanceEditor
   EditInstance,
+  // Tags
+  UpdateTag,
+  GetTag,
+  GetTagBpid,
   // Multiple Setters
   SetInstances,
   WriteInstances,

--- a/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
@@ -133,6 +133,10 @@ function UpdateTag(inputId: string, bpName: string) {
   // STATE._publishState({ tags });
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function GetTags() {
+  return STATE._getKey('tags');
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function GetTag(inputId: string) {
   const tags = STATE._getKey('tags');
   return tags.find(t => t.id === inputId);
@@ -322,6 +326,7 @@ export {
   EditInstance,
   // Tags
   UpdateTag,
+  GetTags,
   GetTag,
   GetTagBpid,
   // Multiple Setters

--- a/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-instances.ts
@@ -29,7 +29,8 @@ STATE.initializeState({
     }
   ],
   instanceidList: [],
-  currentInstance: undefined
+  currentInstance: undefined,
+  tags: []
   // currentInstance is the instance currently being edited
   // it should be undefined by default
   //

--- a/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
@@ -119,6 +119,23 @@ export const POZYX_TRANSFORM = {
   useAccelerometer: true
 };
 
+const FAKETRACK_TRANSFORM = {
+  scaleX: 1,
+  scaleY: 1,
+  translateX: 0,
+  translateY: 0,
+  rotation: 0,
+  useAccelerometer: false
+};
+
+const TRANSFORMS = {};
+TRANSFORMS[TYPES.Undefined] = PTRACK_TRANSFORM;
+TRANSFORMS[TYPES.Object] = PTRACK_TRANSFORM;
+TRANSFORMS[TYPES.People] = PTRACK_TRANSFORM;
+TRANSFORMS[TYPES.Pose] = PTRACK_TRANSFORM;
+TRANSFORMS[TYPES.Pozyx] = POZYX_TRANSFORM;
+TRANSFORMS[TYPES.Faketrack] = FAKETRACK_TRANSFORM;
+
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_Transform(
   position: {
@@ -226,9 +243,11 @@ const ENTITY_TO_COBJ = new SyncMap({
 });
 ENTITY_TO_COBJ.setMapFunctions({
   onAdd: (entity: any, cobj: InputDef) => {
-    const TRANSFORM =
-      entity.type === TYPES.Pozyx ? POZYX_TRANSFORM : PTRACK_TRANSFORM;
-    const { x, y } = m_Transform({ x: entity.x, y: entity.y }, TRANSFORM);
+    const TRANSFORM = TRANSFORMS[entity.type] || TRANSFORMS[TYPES.Faketrack]; // default to faketrack no transforms
+    const { x, y } = m_Transform(
+      { x: Number(entity.x), y: Number(entity.y) },
+      TRANSFORM
+    );
     cobj.x = x;
     cobj.y = y;
     // HACK Blueprints into cobj
@@ -251,9 +270,8 @@ ENTITY_TO_COBJ.setMapFunctions({
     });
   },
   onUpdate: (entity: any, cobj: InputDef) => {
-    const TRANSFORM =
-      entity.type === TYPES.Pozyx ? POZYX_TRANSFORM : PTRACK_TRANSFORM;
-    let pos = { x: entity.x, y: entity.y };
+    const TRANSFORM = TRANSFORMS[entity.type] || TRANSFORMS[TYPES.Faketrack]; // default to faketrack no transforms
+    let pos = { x: Number(entity.x), y: Number(entity.y) };
     if (entity.acc && TRANSFORM.useAccelerometer) {
       // has accelerometer data
       pos = m_PozyxDampen(cobj, pos, entity.acc); // dampen + transform

--- a/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
@@ -225,14 +225,6 @@ function m_PozyxDampen(
   return { x, y };
 }
 
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-function GetDefaultPozyxBpName() {
-  return ACBlueprints.GetPozyxControlDefaultBpName();
-}
-function GetDefaultPTrackBpName() {
-  return ACBlueprints.GetPTrackControlDefaultBpName();
-}
 ///////////////////////////////////////////////////////////////////////////////
 /// ENTITY_TO_COBJ (was POZYX_TO_COBJ) /////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -250,11 +242,12 @@ ENTITY_TO_COBJ.setMapFunctions({
     );
     cobj.x = x;
     cobj.y = y;
-    // HACK Blueprints into cobj
-    cobj.bpid =
-      entity.type === TYPES.Pozyx
-        ? GetDefaultPozyxBpName()
-        : GetDefaultPTrackBpName();
+
+    cobj.bpid = ACBlueprints.GetDefaultInputBpName(entity.type);
+    // If user has selected a different bp for tags (pozyx, ptrack), use the override
+    const tagBpid = ACBlueprints.GetInputBp(cobj.id);
+    if (tagBpid !== undefined) cobj.bpid = tagBpid;
+
     cobj.label = entity.type === TYPES.Pozyx ? entity.id.substring(2) : entity.id;
     cobj.framesSinceLastUpdate = 0;
     UR.SendMessage('NET:SRV_RTLOG', {
@@ -281,9 +274,16 @@ ENTITY_TO_COBJ.setMapFunctions({
 
     cobj.x = pos.x;
     cobj.y = pos.y;
-    cobj.bpid = cobj.bpid; // keep the same blueprint
+
+    // If user has selected a different bp for tags (pozyx, ptrack), use the override
+    const tagBpid = ACBlueprints.GetInputBp(cobj.id);
+    if (tagBpid !== undefined && tagBpid !== cobj.bpid) {
+      cobj.bpid = tagBpid;
+    } else cobj.bpid = cobj.bpid; // keep the same blueprint
+
     cobj.label = entity.type === TYPES.Pozyx ? entity.id.substring(2) : entity.id;
     cobj.framesSinceLastUpdate = 0;
+
     UR.SendMessage('NET:SRV_RTLOG', {
       event: entity.type,
       items: [

--- a/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
@@ -122,6 +122,8 @@ export const POZYX_TRANSFORM = {
   useAccelerometer: true
 };
 
+// FakeTrack transforms are actually handled by FakeTrack itself.
+// Since all inputs are transformed, we use FAKETRACK_TRANSFORM to support a 1-to-1 transform
 const FAKETRACK_TRANSFORM = {
   scaleX: 1,
   scaleY: 1,

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
@@ -98,8 +98,9 @@ function m_CalculateScale(agent: IAgent): { scale: number; scaleY: number } {
  */
 function m_getAgent(agentId): IAgent {
   const a = GetAgentById(agentId);
-  if (!a) COSTUME_AGENTS.delete(agentId);
-  return a;
+  // Also delete if agent has switched bp and no longer has the feature
+  if (!a || !a.prop.Costume) COSTUME_AGENTS.delete(agentId);
+  else return a;
 }
 
 /// UPDATES ////////////////////////////////////////////////////////////////////

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
@@ -43,8 +43,9 @@ const WIDGET_AGENTS = new Map();
  */
 function m_getAgent(agentId): IAgent {
   const a = GetAgentById(agentId);
-  if (!a) WIDGET_AGENTS.delete(agentId);
-  return a;
+  // Also delete if agent has switched bp and no longer has the feature
+  if (!a || !a.prop.Graphing) WIDGET_AGENTS.delete(agentId);
+  else return a;
 }
 
 /// WIDGETS LOOP ////////////////////////////////////////////////////////////

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-movement.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-movement.ts
@@ -566,7 +566,8 @@ function m_InputsUpdate(frame) {
   // 2. Decide on Movement
   const agents = [...MOVEMENT_AGENTS.values()];
   agents.forEach(agent => {
-    if (!agent) return;
+    // Also ignore if agent has switched bp and no longer has the feature
+    if (!agent || !agent.prop.Movement) return;
     // being controlled by a cursor
     if (agent.cursor) m_QueuePosition(agent, agent.cursor.x, agent.cursor.y);
   });

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-physics.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-physics.ts
@@ -52,8 +52,9 @@ const PHYSICS_AGENTS = new Map();
  */
 function m_getAgent(agentId): IAgent {
   const a = SIMAGENTS.GetAgentById(agentId);
-  if (!a) PHYSICS_AGENTS.delete(agentId);
-  return a;
+  // Also delete if agent has switched bp and no longer has the feature
+  if (!a || !a.prop.Physics) PHYSICS_AGENTS.delete(agentId);
+  else return a;
 }
 
 /// PHYSICS LOOP ////////////////////////////////////////////////////////////

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-touches.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-touches.ts
@@ -93,8 +93,9 @@ const AGENT_TOUCHTYPES = new Map(); // Touch-enabled Agents
  */
 function m_GetAgent(agentId): IAgent {
   const a = SIMAGENTS.GetAgentById(agentId);
-  if (!a) AGENT_TOUCHTYPES.delete(agentId);
-  return a;
+  // Also delete if agent has switched bp and no longer has the feature
+  if (!a || !a.prop.Touches) AGENT_TOUCHTYPES.delete(agentId);
+  else return a;
 }
 
 function m_Clear(agent: IAgent) {

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-vision.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-vision.ts
@@ -38,8 +38,9 @@ const VISION_AGENTS = new Map();
  *  WIDGET_AGENTS */
 function m_getAgent(agentId): IAgent {
   const a = SIMAGENTS.GetAgentById(agentId);
-  if (!a) VISION_AGENTS.delete(agentId);
-  return a;
+  // Also delete if agent has switched bp and no longer has the feature
+  if (!a || !a.prop.Vision) VISION_AGENTS.delete(agentId);
+  else return a;
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function m_updateVisionCone(agent): { visionPoly: any[]; visionPath: any[] } {


### PR DESCRIPTION
Addresses #760 

# Features

![screenshot_1336](https://github.com/theRAPTLab/gsgo/assets/1403057/ff0c6a97-894d-48fd-8339-4f783affed19)

* Pozyx tags are now listed in the "CHARACTER CONTROLLERS" panel on Main.
* FakeTrack and PTrack controllers are also listed.
* Any input source (pozyx, faketrack, ptrack) can select a new character blueprint at any time.
* When the blueprint is changed, a new agent is created and the old one is removed.  So any state that the agent had is lost.

* If none of the scripts have set controllable inputs (e.g. no blueprints have `isPozyxControllable` or `isPTrackControllable` set to true), the "CHARACTER CONTROLLERS" panel on Main will select the first blueprint by default and issue a warning on the dev console.  This is to prevent the app from crashing.

* FakeTrack functionality has been restored.  Transforms weren't properly calculated for faketrack inputs, so nothing was working.  98f01b96c9d8df209253e819f39ce7bbff615aca adds support that defaults to a faketrack transform (e.g. no transform) so that faketrack entities can be displayed and controlled/moved again.


## To Test/Implement

Test Mapping

1. Make sure one blueprint has `# TAG isPozyxControllable true` set to `true`.  This will be the default blueprint that any new tag is set to.  (You can set more than one `isPozyxControllable`.  If there is more than one, one of the `isPozyxControllable` blueprints will be picked at random.)
2. Start Main
3. Move some pozyx tags around (or use the pozyx Gateway simulator to generate some fake tags).
4. A list of active tags will show in the "CHARACTER CONTROLLERS" area.
5. The active tags will default to the first `isPozyxControllable` blueprint.
6. FakeTrack inputs will default to the first blueprint, since it ignores `isPozyxControllable`.
7. Select any other blueprint from the popup menu for each tag to select a new blueprint type.
8. The old agent will be removed and a new agent created in its place.
9. The old agent state will be lost -- data is not ported from the old blueprint instance to the new blueprint instance.

Test "No Controllable Tag" Tracking

1. Set `isPozyxControllable` and `isPTrackControllable` for all blueprints to false.
2. Run the simulation.
3. The console should not generate any errors
4. Pozyx and PTrack inputs should use a random default blueprint -- this will be randomly selected
5. FakeTrack inputs should default to the first blueprint on the list .


## Caveats

* The list of "CHARACTER CONTROLLERS" on the map will show Character Controllers with their controller ID, but not the selected blueprint name. That information is not currently easily accessed.  It should be possible to address this in future work.  

---

# Technical Background

During each sim loop, inputs coming from PTrack, Pozyx, Character Controllers, and FakeTrack are mapped to agent instance definitions and agents are then created.  We tap into that flow by introducing a way to dynamically select a new agent instance from the list of available agents.  The process is something like this (see the [input to agent flow](https://whimsical.com/input-to-agent-flow-XjPthAzmLFR381wX1RiUuo) whimsical diagram):

1. pozyx tags are updated with inputs.  
6. We detect when a new tag has been added.  When a tag is added, we update a new `instances` state group called `tags` that lists all of the available PTrack, Pozyx, and FakeTrack inputs and their corresponding blueprint names.
7. Those `tags` are listed on the "CHARACTER CONTROLLERS" panel on Main, along with a menu selector for all of the blueprint types that are available.
8. By default, pozyx tags use the default blueprint specified with a `isPozyxControllable` tag.
10. When a tag is selected on the "CHARACTER CONTROLLERS" panel on Main, we update the `tags` group of the `instances` state with a new blueprint id.
11. During the regular simloop update in `dc-inputs`, we add or change the agent definitions using the `tags` table.
12. Later during the `sim-inputs` phase, the agent definitions are mapped to agent instances, either updating or adding a new agent as necessary.  The old agent is removed, and a new agent is created.  State is not maintained across the two agents.

NOTE: WIth this system, ANY blueprint can be controlled by a pozyx tag.  The `# TAG isPozyxControllable` tag is not necessary to make it controllable.  The corollary to this is that we are not excluding any blueprints either.  If exclusion is necessary, we'll need to add a filter to do that.

---


## TO DO
* [x] Not all code has been pushed to the repo yet.
* [x] Crashes if no blueprint has`isPozyxControllable` set to true.
* [x] Test with working pozyx system and working simulation to make sure agent GEMSCRIPTS are working properly
* [x] List only pozyxControllable tags
* [x] predator faketrack error
* [x] character name split
* [x] tags need to be updated after saving map
