### PR TITLE
Fix GEMSTEP Installation for M1 (ARM) Macs

### DIFF
--- a/.vscode/check_env
+++ b/.vscode/check_env
@@ -1,0 +1,52 @@
+# The following script is invoked on Apple OSX machines
+# in the .code-workspace setting "terminal.integrated.profiles.osx"
+
+#
+# (1) Ensure NVM Version is Obeyed in Shell
+#
+NODE_PREFERRED="v18.16.0"
+NVM_FORCE_DEFAULT=0
+
+# ANSI Terminal Colors
+ALRT="\e[33;1m" # yellow
+INFO="\e[34;1m" # blue
+NRML="\e[0m"    # normal
+BOLD="\e[1m"    # normal bold
+
+# Check if NVM_DIR is defined
+if [ -z "$NVM_DIR" ]; then
+  echo ""
+  echo "vsenv: ${ALRT}NVM does not appear to be installed${NRML}"
+  echo "       Does your ${INFO}~/.zshrc${NRML} have ${INFO}export NVM_DIR${NRML} lines?"
+  echo ""
+  echo "       If you haven't installed nvm yet, please follow the instructions"
+  echo "       on the NetCreate wiki."
+  echo "       If you are using 'bash' as your default shell, you can copy "
+  echo "       these lines to your .zshrc file so nvm will also work in zsh."
+  return
+fi
+
+
+# Check if shell is opening inside a VSCODE integrated terminal
+# is NVM is installed, there is a .nvmrc file and a .vscode directory?
+if [ -n "$NVM_DIR" ] && [ -s "./.nvmrc" ] && [ -d "./.vscode" ]; then
+  NODE_VERSION=$(cat ./.nvmrc)
+  str_out="(nvm)";
+  str_alias=$(nvm alias default "$NODE_VERSION")
+  str_use=$(nvm use "$NODE_VERSION")
+  if [ -n "$str_use" ]; then
+    str_out="$str_out current version"
+  fi
+  if [ -n "$str_alias" ]; then
+    str_out="$str_out and alias"
+  fi
+  echo ""
+  echo "vsenv: VISUAL STUDIO CODE INTEGRATED TERMINAL DETECTED"
+  echo "       ${str_out} detected setting: node ${INFO}$NODE_VERSION${NRML}"
+  CURRENT_VERSION=$(node --version)
+  if [ "$CURRENT_VERSION" != "$NODE_VERSION" ] && [ -n "$str_alias" ] && [ $NVM_FORCE_DEFAULT ]; then
+    echo "vsenv: ${BOLD}kill/restart VSCODE for nvm alias default to take effect!${NRML}"
+    echo "       this shell is using version ${INFO}$CURRENT_VERSION${NRML} until you do"
+    echo "       alternatively, type ${ALRT}nvm use $NODE_VERSION${NRML} to use it now"
+  fi
+fi

--- a/.vscode/check_env
+++ b/.vscode/check_env
@@ -26,27 +26,24 @@ if [ -z "$NVM_DIR" ]; then
   return
 fi
 
-
 # Check if shell is opening inside a VSCODE integrated terminal
 # is NVM is installed, there is a .nvmrc file and a .vscode directory?
 if [ -n "$NVM_DIR" ] && [ -s "./.nvmrc" ] && [ -d "./.vscode" ]; then
   NODE_VERSION=$(cat ./.nvmrc)
   str_out="(nvm)";
-  str_alias=$(nvm alias default "$NODE_VERSION")
   str_use=$(nvm use "$NODE_VERSION")
-  if [ -n "$str_use" ]; then
-    str_out="$str_out current version"
-  fi
-  if [ -n "$str_alias" ]; then
-    str_out="$str_out and alias"
-  fi
-  echo ""
   echo "vsenv: VISUAL STUDIO CODE INTEGRATED TERMINAL DETECTED"
-  echo "       ${str_out} detected setting: node ${INFO}$NODE_VERSION${NRML}"
+  echo "       ${str_out} desired node version is ${INFO}$NODE_VERSION${NRML}"
   CURRENT_VERSION=$(node --version)
-  if [ "$CURRENT_VERSION" != "$NODE_VERSION" ] && [ -n "$str_alias" ] && [ $NVM_FORCE_DEFAULT ]; then
-    echo "vsenv: ${BOLD}kill/restart VSCODE for nvm alias default to take effect!${NRML}"
-    echo "       this shell is using version ${INFO}$CURRENT_VERSION${NRML} until you do"
-    echo "       alternatively, type ${ALRT}nvm use $NODE_VERSION${NRML} to use it now"
+  if [ "$CURRENT_VERSION" != "$NODE_VERSION" ]; then
+    echo ""
+    echo "vsenv: This shell is using ${INFO}$CURRENT_VERSION${NRML} instead of ${INFO}$NODE_VERSION${NRML}"
+    echo "       Type ${ALRT}nvm use $NODE_VERSION${NRML} to use the correct version!"
+    echo ""
+    echo "       Alternatively type ${ALRT}nvm alias default $NODE_VERSION${NRML} to"
+    echo "       set it system-wide and then ${ALRT}restart Visual Studio Code${NRML} for"
+    echo "       it to take effect. This may break your other NodeJS projects"
+    echo "       if you do not use nvm to actively enforce version requirments."
+    echo ""
   fi
 fi

--- a/gs_packages/gem-srv/gem_run.js
+++ b/gs_packages/gem-srv/gem_run.js
@@ -19,13 +19,19 @@ const Process = require('process');
 const Shell = require('shelljs');
 const Minimist = require('minimist');
 const UR = require('@gemstep/ursys/server');
+const EXEC = require('child_process').exec;
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const PR = 'GEMRUN';
 const TOUT = UR.TermOut(PR);
+const WR = s => `${PR} ${DP} \x1b[1;34m${s}\x1b[0m`;
+const BL = s => `\x1b[1;34m${s}\x1b[0m`;
+const YL = s => `\x1b[1;33m${s}\x1b[0m`;
+const ERR = s => `\x1b[33;41m ${s} \x1b[0m`;
 
-// ensure that local settings file exists
+/// ENSURE LOCAL SETTINGS FILE EXISTS /////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const localSettingsPath = Path.join(__dirname, 'config/local-settings.json');
 if (!UR.FILE.FileExists(localSettingsPath)) {
   TOUT('creating empty config/local-settings.json file');
@@ -37,6 +43,54 @@ if (!UR.FILE.FileExists(localSettingsPath)) {
     ]
   });
 }
+
+/// CHECK ARCH ////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// check architecture
+EXEC('arch', (error, stdout, stderr) => {
+  if (stdout) {
+    stdout = stdout.trim();
+    if (stdout !== 'i386') {
+      TOUT(`ARCHITECTURE: ${stdout}`);
+      TOUT(ERR('NOTICE: NETCREATE TESTED ON X86 NODEJS LIBRARIES'));
+      TOUT(ERR('ARM-based Macs must use i386-compatible shell'));
+      const cmd = `arch -x86_64 ${process.env.SHELL}`;
+      TOUT(`Type the following into terminal, then ${YL('try again')}:`);
+      TOUT(`  ${YL(cmd)}`);
+      TOUT(
+        `NOTE: you might need to ${BL(
+          'npm ci; npm run bootstrap'
+        )} again if this is a fresh GEMSTEP install`
+      );
+      process.exit(101);
+    } else {
+      TOUT(`architecture is ${stdout}`);
+    }
+  }
+});
+
+/// CHECK NODE VERSION ////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+let NODE_VER;
+try {
+  NODE_VER = FS.readFileSync('../../.nvmrc', 'utf8').trim();
+} catch (err) {
+  TOUT(ERR('could not read .nvmrc', err));
+  throw Error(`Could not read .nvmrc ${err}`);
+}
+EXEC('node --version', (error, stdout, stderr) => {
+  if (stdout) {
+    stdout = stdout.trim();
+    if (stdout !== NODE_VER) {
+      TOUT(ERR('NODE VERSION MISMATCH'));
+      TOUT(`.. expected ${NODE_VER} got ${YL(stdout)}`);
+      TOUT(`.. did you remember to run ${BL('nvm use')}?`);
+      // eslint-disable-next-line no-process-exit
+      process.exit(102);
+    }
+    TOUT('nodejs version is', stdout);
+  }
+});
 
 /// LOAD GEMSTEP DEPENDENCIES /////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/gem-srv/gem_run.js
+++ b/gs_packages/gem-srv/gem_run.js
@@ -57,11 +57,11 @@ EXEC('arch', (error, stdout, stderr) => {
       const cmd = `arch -x86_64 ${process.env.SHELL}`;
       TOUT(`Type the following into terminal, then ${YL('try again')}:`);
       TOUT(`  ${YL(cmd)}`);
-      TOUT(
-        `NOTE: you might need to ${BL(
-          'npm ci; npm run bootstrap'
-        )} again if this is a fresh GEMSTEP install`
-      );
+      TOUT(`NOTE: you may need to ${BL('npm ci; npm run bootstrap')}`);
+      TOUT(`again if this is a fresh GEMSTEP install.`);
+      TOUT(`If you ran ${BL('npm install')} with the wrong arch, you`);
+      TOUT(`may need to ${ERR('re-pull')} the repo again to recover.`);
+      TOUT(`Ask the devteam for help!`);
       process.exit(101);
     } else {
       TOUT(`architecture is ${stdout}`);
@@ -83,8 +83,8 @@ EXEC('node --version', (error, stdout, stderr) => {
     stdout = stdout.trim();
     if (stdout !== NODE_VER) {
       TOUT(ERR('NODE VERSION MISMATCH'));
-      TOUT(`.. expected ${NODE_VER} got ${YL(stdout)}`);
-      TOUT(`.. did you remember to run ${BL('nvm use')}?`);
+      TOUT(`... expected ${NODE_VER} got ${YL(stdout)}`);
+      TOUT(`... did you remember to run ${BL('nvm use')}?`);
       // eslint-disable-next-line no-process-exit
       process.exit(102);
     }

--- a/gsgo.code-workspace
+++ b/gsgo.code-workspace
@@ -22,7 +22,22 @@
       "gs_packages/gem-srv/node_modules": true,
       "gs_packages/gem-srv/package-lock.json": true,
       "node_modules": true,
-      "package-lock.json": true,
+      "package-lock.json": true
+    },
+    "terminal.integrated.profiles.osx": {
+      "x86 macos": {
+        "path": "/usr/bin/arch",
+        "args": [
+          "-arch",
+          "x86_64",
+          "${env:SHELL}",
+          "-i",
+          "-c",
+          "export VSCODE_PROFILE='x86 shell';source .vscode/check_env; exec ${env:SHELL}"
+        ]
+      }
     }
+    // uncomment to force
+    // "terminal.integrated.defaultProfile.osx": "x86 macos"
   }
 }


### PR DESCRIPTION
GEMSTEP does not install correctly on M-series Macintoshes as they use the ARM CPU architecture, and the version of NodeJS that this codebase is tied to **does not know how to work with it correctly** and leads to numerous mysterious errors.

The workaround is to **force Intel i386 mode** with the `arch` command, but you have to do it correctly from a fresh installation. This pull request adds additional detection code to `gem-srv` that will prompt users to correct the problem. It's suggested that this is added to the installation instruction as well, since Intel Macs are no longer being produced.

## TEST 1: GATHER INFO

There are four important contexts to check for the runtime environment, which you can grab by running this command line:
```
node -v; arch; echo $0; git branch --show-current; nvm which
```
The output should be:
```
v14.21.3
i386
/bin/zsh (or /bin/bash)
( whatever branch you are on )
Found '.nvmrc' with version <v14.21.3>
( other stuff )
```
If the version and architecture lines do not match, then your terminal shell is misconfigured and `npm run gem` may fail. The next test will detect and prompt you about the issues.

## TEST 2: DETECT ENVIRONMENT MISMATCH

The `gem-run.js` file now checks both the node version and the cpu architecture for matches. 
```
npm run gem
```

### WHEN EVERYTHING CHECKS OUT
![image](https://github.com/theRAPTLab/gsgo/assets/11952933/90b25242-366d-4939-bf05-f704e9178916)

#### WRONG NODE VERSION
![image](https://github.com/theRAPTLab/gsgo/assets/11952933/cf4e3699-b6d5-4324-a3f2-8ee1791a2bda)

#### WRONG ARCHITECTURE
![image](https://github.com/theRAPTLab/gsgo/assets/11952933/dd9401e2-eb54-4b0a-aabf-ca1fe25c4f3a)

## TEST 3: RUN GEMSTEP NORMALLY

To make sure everything is still working correctly, do your normal GEMSTEP development and runtime activities and report any issues!

1. Does your current student activity still work as expected?
2. Does the source code you are working on still seem to run correct?

## TEST 4: ENABLE AUTOFORCING NVM SCRIPT

The project's `.vscode` folder (normally hidden) contains a script called `check_env` which will try to automatically force the `arch` command and apply `nvm use` for you. It works only on Macs and ensures that i386 architecture is set AND that the official Node version is being used as defined in the `.nvmrc` file

To test, you have to uncomment a section in the `gsgo.code-workspace` and then start a fresh *integrated terminal* session from VSCODE. This script does not run outside of VSCODE's environment.

1. open the file `gsgo/gsgo.code-workspace`
2. At the bottom of this file, look for the following block of text 
![image](https://github.com/theRAPTLab/gsgo/assets/2048828/392a2c4f-7c62-41b9-900c-621459af1580)
3. Uncomment the line `"terminal.integrated.defaultProfile.osx": "x86 macos"` and save the file.
4. Under the VSCODE File menu, pick `Close Workspace`. If the option is disabled, you were not using the official project workspace and you should start using it to ensure compatibility with settings inside it.
5. Quit VSCode completely.
6. Reopen VSCode, and from the File menu choose `Open Workspace`. Find the `gsgo.code-workspace` file and open it.
7. Open the terminal window with CTRL-TILDE (~) and you should see something like this: 
![image](https://github.com/theRAPTLab/gsgo/assets/2048828/c6805b65-0de5-4f78-87f8-65e198ac3e7d)
8. The message may vary and tell you to quit/restart again. 

You can rerun the information-gathering commands again to confirm that the correct  node version and architecture is running:
```
node -v; arch; echo $0; git branch --show-current; nvm which
```

9. Every time you quit and restart visual studio code with the `gsgo.code-workspace`, your settings will be enforced so you don't have to remember to do it.

## BONUS TEST: MANUAL INSTALL ON NEW MAC

Using the existing `dev-next` branch, try to configure from scratch **manually** without the new code and see if it works! Here is the quickie setup. 

_Note that the default `gsgo` and `art-assets` branches may not be working, so you might need to find out what the 'latest working set' is from someone. For example, at the time of this writing `dev-next` is tuned for a specific art-assets branch called `fall_2023_cross-site`_
```
git clone git@github.com:theRAPTLab/gsgo.git  
cd gsgo
git checkout dev-next

echo '{"GS_ASSETS_PROJECT_ROOT":"art-assets"}' > gs_packages/gem-srv/config/local-settings.json

mkdir gs_assets
cd gs_assets
git clone git@github.com:theRAPTLab/art-assets.git
cd ..
```
Next you'll manually check the environment
```
node -v; arch; echo $0; git branch --show-current; nvm which
```
Then you'll force the environment to be correct:
```
arch -x86_64 $0
nvm use
```
Then you'll try running the build and hopefully everything just works
```
npm ci
npm run bootstrap
npm run gem
```
Open up a browser window to `http://localhost`
