### PR TITLE
Feature: ColorPicker

### DIFF
--- a/gs_packages/gem-srv/src/app/help/codex-types.yaml
+++ b/gs_packages/gem-srv/src/app/help/codex-types.yaml
@@ -22,6 +22,11 @@ number:
   input: 'Enter digits. You may use a decimal point'
   info: 'Number properties can store numbers, including decimal points'
 
+color:
+  name: 'color (numeric value)'
+  input: 'Click to select a color.'
+  info: 'Colors are stored as number properties'
+
 identifier:
   name: 'identifier'
   input: 'Enter alphanumeric characters with no spaces or leading numbers'

--- a/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/SharedElements.tsx
@@ -10,6 +10,7 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import React from 'react';
+import * as PIXI from 'pixi.js';
 import { UnpackToken, TokenValue } from 'script/tools/script-tokenizer';
 import { GUI_EMPTY_TEXT } from 'modules/../types/t-script.d'; // workaround to import constant
 import * as CHELPER from 'script/tools/comment-utilities';
@@ -393,6 +394,13 @@ export function GValidationToken(props) {
   if (isRightSide) helpclasses += ' styleRight';
 
   const displayLabel = String(label); // force convert boolean to string
+
+  // show color swatch if gsType is 'color
+  if (type === 'color') {
+    const cssColor = PIXI.utils.hex2string(Number(label));
+    cssStyle = { backgroundColor: cssColor };
+  }
+
   const jsx = isSlot ? (
     <>
       <div className="gwiz gsled meta styleSyntax">

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
@@ -163,7 +163,7 @@ export const ADVANCED_SYMBOLS = [
   'y',
   'statustext',
   'zindex',
-  'color',
+  // 'color', // used by Costume featProp so NOT advanced
   'orientation',
   'visible',
   'alpha',

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/ScriptViewWiz_Block.jsx
@@ -152,7 +152,7 @@ export function ScriptViewWiz_Block(props) {
       lineValidationTokens.forEach((validationToken, idx) => {
         const tokInfo = vmTokens[idx] || {};
         let { tokenKey } = tokInfo;
-        const { gsType } = validationToken;
+        let { gsType, gsName } = validationToken;
         const { scriptToken } = tokInfo;
         let label;
         let selected;
@@ -173,6 +173,12 @@ export function ScriptViewWiz_Block(props) {
           else viewState = 'empty';
           tokenKey = `${lineNum},${idx + 1}`; // generate tokenKey
         }
+        // special color handling -- show color instead of color
+        if (gsName === 'color') {
+          // override gsType?
+          gsType = 'color';
+        }
+
         // locked
         if (LOCKED_SYMBOLS.includes(String(label).toLowerCase())) {
           viewState = 'locked';

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditorSelect_Block.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditorSelect_Block.tsx
@@ -21,6 +21,7 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import React from 'react';
+import * as PIXI from 'pixi.js';
 import * as EDITMGR from 'modules/appcore/ac-editmgr';
 import * as CHECK from 'modules/datacore/dc-sim-data-utils';
 import * as HELP from 'app/help/codex';
@@ -111,6 +112,14 @@ function SlotEditorSelect_Block(props) {
       type: 'expr'
     });
   };
+  const processColorInput = e => {
+    e.preventDefault();
+    let colorstr = PIXI.utils.string2hex(e.target.value);
+    EDITMGR.UpdateSlot({
+      value: colorstr,
+      type: 'value'
+    });
+  };
 
   // Keypress Handlers
   const handleNumberKeypress = e => {
@@ -179,6 +188,20 @@ function SlotEditorSelect_Block(props) {
             type="number"
             onChange={processNumberInput}
             onKeyPress={handleNumberKeypress}
+          />
+        </div>
+      );
+      break;
+    case 'color':
+      const colorstr = PIXI.utils.hex2string(defaultNumber);
+      editor = (
+        <div id="SES_color" className="gsled input">
+          <HelpLabel prompt={helpPrompt} info={helpInfo} open pad="5px" />
+          <input
+            key={tkey}
+            defaultValue={colorstr}
+            type="color"
+            onChange={processColorInput}
           />
         </div>
       );

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/SlotEditor_Block.jsx
@@ -312,6 +312,28 @@ class SlotEditor_Block extends React.Component {
     }
     /// END 3.5. Comment Handling - - - - - - - - - - - - - - - - - - - - - - -
 
+    /// 3.6. Special `COLOR` Handling - - - - - - - - - - - - - - - - - - - - -
+    ///      We inject vtokens for rendering and managing colors
+    ///      and then rely on the standard GValidationToken rendering to handle
+    ///      the rest of the UI.
+    ///      This way the syntax and core script data system remains prisitine
+    ///      and we are only providing visual overrides.
+    ///
+    ///      Look for `setToColor` method.
+    ///      Typical color line is:
+    ///         featProp charactert.Costume.color setToColor xxx
+    ///
+    if (slots_linescript[0] && validationTokenCount > 3) {
+      const vtok = validationTokens[2];
+      if (vtok.unitText === 'setToColor') {
+        // force color value type from gsType 'number' to gsType 'color
+        validationTokens[3].gsType = 'color';
+        validationTokens[3].gsName = 'color'; // for "INSTRUCTIONS"
+      }
+    }
+
+    /// END 3.6. COLOR Handling - - - - - - - - - - - - - - - - - - - - - - -
+
     /// 4. Process each validation token
     let label;
     let extraTokenName;
@@ -598,12 +620,12 @@ class SlotEditor_Block extends React.Component {
     if (isComment) {
       // COMMENT Choices
       choicesjsx = (
-      <div id="SEB_choices" className="gsled choices">
-        <SlotEditor_CommentBlock
-          defaultText={commentText}
-          onChange={this.HandleCommentUpdate}
-        />
-      </div>
+        <div id="SEB_choices" className="gsled choices">
+          <SlotEditor_CommentBlock
+            defaultText={commentText}
+            onChange={this.HandleCommentUpdate}
+          />
+        </div>
       );
     } else if (isDict) {
       // DICT Choices
@@ -635,25 +657,25 @@ class SlotEditor_Block extends React.Component {
     } else {
       // SELECT Choices
       choicesjsx = (
-      <div id="SEB_choices" className="gsled choices">
-        {selectedError && (
+        <div id="SEB_choices" className="gsled choices">
+          {selectedError && (
             <div className="gsled choicesline gwiz styleError">
               {selectedError}
             </div>
-        )}
-        {extraTokenName && (
-          <div className="gsled choicesline gwiz styleError">
-            <button onClick={this.DeleteSlot} style={{ width: 'fit-content' }}>
-              DELETE &quot;{extraTokenName}&quot;
-            </button>
+          )}
+          {extraTokenName && (
+            <div className="gsled choicesline gwiz styleError">
+              <button onClick={this.DeleteSlot} style={{ width: 'fit-content' }}>
+                DELETE &quot;{extraTokenName}&quot;
+              </button>
+            </div>
+          )}
+          <SlotEditorSelect_Block selection={selectEditorSelection} />
+          <div className="gsled choicesline choiceshelp">
+            SELECTED: {selectedChoiceHelpTxt}
           </div>
-        )}
-        <SlotEditorSelect_Block selection={selectEditorSelection} />
-        <div className="gsled choicesline choiceshelp">
-          SELECTED: {selectedChoiceHelpTxt}
         </div>
-      </div>
-    );
+      );
     }
 
     /// save dialog - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
@@ -137,10 +137,15 @@ function m_Update(frame) {
     }
 
     // Set COLOR
+    // COLOR can be set three different ways:
+    // 1. colorScale or
+    // 2. color
+    // 3. HSV
+    // We use HSV as the common denominator base color format,
+    // and convert to HEX when we assign the agent.prop.color.
+    // NOTE: color scale will override any color and hsv settings
     if (agent.prop.Costume.colorScaleIndex.value !== undefined) {
-      // COLOR can be set two different ways: colorScale or HSV
-      // NOTE: color scale will override any hsv settings
-      // retrieve color from color scale
+      // 1. colorScale -- retrieve color from color scale
       color = agent.prop.Costume._colorScale.get(
         agent.prop.Costume.colorScaleIndex.value
       );
@@ -149,8 +154,14 @@ function m_Update(frame) {
       agent.prop.Costume.colorHue.setTo(h);
       agent.prop.Costume.colorSaturation.setTo(s);
       agent.prop.Costume.colorValue.setTo(v);
+    } else if (agent.prop.Costume.color.value !== undefined) {
+      // 2. color hex
+      [h, s, v] = HSVfromHEX(agent.prop.Costume.color.value);
+      agent.prop.Costume.colorHue.setTo(h);
+      agent.prop.Costume.colorSaturation.setTo(s);
+      agent.prop.Costume.colorValue.setTo(v);
     }
-    //   convert feature color data to hex for agent
+    // 3. hsv -- convert feature color data to hex for agent
     h = agent.prop.Costume.colorHue.value;
     s = agent.prop.Costume.colorSaturation.value;
     v = agent.prop.Costume.colorValue.value;
@@ -271,6 +282,10 @@ class CostumePack extends SM_Feature {
     // Costume color will override agent color during m_Update
     prop = new SM_Number();
     this.featAddProp(agent, 'glow', prop); // in seconds
+    prop = new SM_Number();
+    prop.setMax(16777215);
+    prop.setMin(0);
+    this.featAddProp(agent, 'color', prop);
     prop = new SM_Number();
     prop.setMax(1);
     prop.setMin(0);
@@ -535,6 +550,7 @@ class CostumePack extends SM_Feature {
       flipX: SM_Boolean.Symbols,
       flipY: SM_Boolean.Symbols,
       glow: SM_Number.Symbols,
+      color: SM_Number.Symbols, // hex css
       colorHue: SM_Number.Symbols,
       colorSaturation: SM_Number.Symbols,
       colorValue: SM_Number.Symbols,

--- a/gs_packages/gem-srv/src/modules/sim/script/vars/class-sm-number.ts
+++ b/gs_packages/gem-srv/src/modules/sim/script/vars/class-sm-number.ts
@@ -112,6 +112,11 @@ export class SM_Number extends SM_Object implements ISM_Object {
     u_CheckMinMax(this);
     return this;
   }
+  setToColor(num: number) {
+    this.value = num;
+    u_CheckMinMax(this);
+    return this;
+  }
   setToRnd(min: number, max: number, integer: boolean) {
     this.value = u_RND(min, max, integer);
     u_CheckMinMax(this);
@@ -257,6 +262,10 @@ export class SM_Number extends SM_Object implements ISM_Object {
       setTo: {
         args: ['number:number'],
         info: 'Sets the property to a value'
+      },
+      setToColor: {
+        args: ['color:number'],
+        info: 'Sets the property to a color value'
       },
       setToRnd: {
         args: ['min value:number', 'max value:number', 'asInteger:boolean'],


### PR DESCRIPTION
This adds a color picker to the wizard.

<img width="1872" alt="screenshot_1349" src="https://github.com/theRAPTLab/gsgo/assets/1403057/618e76a7-ad36-43e7-969e-b2692affd6d5">

This is implemented via three additions:
1. GVar Numbers now have a `setToColor` method.
2. The Costume Feature now has a `color` featProp.
3. The Wizard view now shows a color swatch for the color value in both the line and slot editor views.

# To Set a Color
1. Make sure your character has `addFeature Costume`
2. Set the color via a `featProp` call using the `setToColor` method, e.g. `featProp character.Costume.color setToColor`.
3. Click on the color slot to enable color picking.
4. Click on the colors watch to select a new color.
5. Use the sliders or click on a color to set the color -- the color will be immediately set and the numerical color value will also be immediately set.
6. Save the line, and Save to Server.
7. In Main, the character will have a color overlay.

# `setToColor` method
Colors are implemented as GVar numbers.  We added a new method to explicitly set the color.  Under the hood, you could use `setTo` or `setToColor` to set a color, but with `setTo` you would have to enter a number, while with `setToColor` you would be able to use a color picker.

Implementing `setToColor` as a method for GVar Numbers allows us to keep the simulation and script engines fairly simple, with color setting added purely as a visual editor tool, similar to the way Comment Styles are implemented -- the simulation and script engines do not need to be modified to accommodate colors because they are operating as pure numbers.

# `color` Costume Feature
There are many ways to set character colors (see all the `featCall` methods and `featProps`  for `Costume`), each of which may override others.  In general, we recommend using the `featProp character.Costume.color setToColor` approach.

Priority Order
During each Costume update loop, colors are applied in this order:
* ColorScaleIndex -- if a ColorScaleIndex value is set, it will override any `color` featProp (used for Moths to set a graduated scale of white to black moths).
* `color` featProp -- If the `color` featProp is set, it will override other color `featCall` methods and `featProps`
* HSV values from featProp or featCalls -- Otherwise, the character will use the HSV values previously set by any `featCall` or `featProp`s.

Note that you should NOT use `agent.prop.color` to set color as `agent.prop.color` is overwritten by the Costume Feature with each update loop.

# Colors in Wizard View
Colors set by the `setToColor` method will now show swatches in the Script Editor Line vie as well as the Script Editor Slot Editor view.

Addresses #779 

# TO DO 
* [x] Remove `color` from expert props/methods in slot editor
* [x] Update wiki/script reference