### PR TITLE
Feature: `glowColor`

### DIFF
--- a/gs_packages/gem-srv/src/app/help/codex-features.yaml
+++ b/gs_packages/gem-srv/src/app/help/codex-features.yaml
@@ -85,6 +85,8 @@ Costume:
     info: 'Flip the costume on the y axis (vertically).'
   glow:
     info: 'Set costume to glow for n number of seconds. If you set this to 0 it will stop glowing immediately.'
+  glowColor:
+    info: 'Set color of costume glow.  Defaults to yellow.'
   currentFrame:
     info: 'If you are using a character with multiple frames (e.g., a .json file), this sets it to a new one.'
   colorHue:

--- a/gs_packages/gem-srv/src/lib/class-sm-agent.ts
+++ b/gs_packages/gem-srv/src/lib/class-sm-agent.ts
@@ -29,6 +29,7 @@ const INTERNAL_PROPS: TPropRecord[] = [
   { name: 'trackerId', type: 'string' },
   { name: 'zIndex', type: 'number' },
   { name: 'color', type: 'number' },
+  { name: 'glowColor', type: 'number' },
   { name: 'scale', type: 'number' },
   { name: 'scaleY', type: 'number' },
   { name: 'orientation', type: 'number' },
@@ -96,6 +97,7 @@ class SM_Agent extends SM_Object implements IAgent, IActable {
     this.prop.zIndex = new SM_Number();
     this.prop.skin = new SM_String();
     this.prop.color = new SM_Number();
+    this.prop.glowColor = new SM_Number();
     this.prop.scale = new SM_Number();
     this.prop.scale.setMax(10);
     this.prop.scale.setMin(-10);
@@ -163,6 +165,12 @@ class SM_Agent extends SM_Object implements IAgent, IActable {
   }
   set color(num: number) {
     this.prop.color.value = num;
+  }
+  get glowColor() {
+    return this.prop.glowColor.value;
+  }
+  set glowColor(num: number) {
+    this.prop.glowColor.setTo(num);
   }
   get scale() {
     return this.prop.scale.value;

--- a/gs_packages/gem-srv/src/lib/class-visual.ts
+++ b/gs_packages/gem-srv/src/lib/class-visual.ts
@@ -50,7 +50,6 @@ let REF_ID_COUNTER = 0;
 /// outline filters
 const outlineHover = new OutlineFilter(3, 0xffff0088);
 const outlineSelected = new OutlineFilter(6, 0xffff00);
-const glow = new GlowFilter({ distance: 50, outerStrength: 3, color: 0xffff00 });
 
 // replacement for GLOBAL sprite
 const SPRITES = ASSETS.GetLoader('sprites');
@@ -115,6 +114,7 @@ class Visual implements IVisual, IPoolable, IActable {
   textContent: string; // cache value to avoid unecessary updates
   meterValue: number;
   assetId: number;
+  glow: GlowFilter; // PIXI.GlowFilter
   isSelected: boolean;
   isHovered: boolean;
   isGrouped: boolean;
@@ -144,6 +144,11 @@ class Visual implements IVisual, IPoolable, IActable {
     this.container.addChild(this.filterbox);
     this.assetId = 0;
     this.refId = REF_ID_COUNTER++;
+    this.glow = new GlowFilter({
+      distance: 50,
+      outerStrength: 3,
+      color: 0xffff00
+    });
     this.isSelected = false; // use primary selection effect
     this.isHovered = false; // use secondary highlight effect
     this.isGrouped = false; // use tertiary grouped effect
@@ -234,6 +239,13 @@ class Visual implements IVisual, IPoolable, IActable {
     this.filterAdjustment = new AdjustmentFilter({ red: r, green: g, blue: b });
   }
   /**
+   * glowColor is yellow by default
+   * This only runs if the agent has set a glowColor
+   */
+  setGlowColor(color: number) {
+    this.glow.color = color;
+  }
+  /**
    * Call this AFTER
    *  setAlpha
    *  setTexture
@@ -245,7 +257,7 @@ class Visual implements IVisual, IPoolable, IActable {
     const spriteFilters = []; // filters for the sprite texture only
     if (this.isSelected) filters.push(outlineSelected);
     if (this.isHovered) filters.push(outlineHover);
-    if (this.isGlowing) filters.push(glow);
+    if (this.isGlowing) filters.push(this.glow);
     if (this.filterColorOverlay) spriteFilters.push(this.filterColorOverlay);
     if (this.filterAdjustment) spriteFilters.push(this.filterAdjustment);
     if (this.isSelected || this.isHovered) {

--- a/gs_packages/gem-srv/src/modules/render/api-render.js
+++ b/gs_packages/gem-srv/src/modules/render/api-render.js
@@ -119,6 +119,8 @@ function Init(element) {
       else if (dobj.barGraph !== undefined) {
         vobj.setBarGraph(dobj.barGraph, dobj.barGraphLabels);
       }
+      if (dobj.glowColor !== undefined)
+        vobj.setGlowColor(dobj.glowColor);
 
       // Set selection state from flags.
       // This needs to be set before the setTexture call
@@ -166,6 +168,8 @@ function Init(element) {
         vobj.sprite.tint = 0xff0000;
         vobj.sprite.alpha = 0.5;
       }
+      if (dobj.glowColor !== undefined)
+        vobj.setGlowColor(dobj.glowColor);
 
       // inefficient texture update
       vobj.setVisible(dobj.visible);
@@ -214,7 +218,7 @@ function Init(element) {
       else vobj.removeDebug();
     },
     shouldRemove: () => true,
-    onRemove: () => {}
+    onRemove: () => { }
   });
   // make sure datacore has access to it for pure data manipulation
   SetModelRP(RP_DOBJ_TO_VOBJ);
@@ -238,7 +242,7 @@ function Init(element) {
       vobj.setPosition(ent.x * SCALE, ent.y * SCALE);
     },
     shouldRemove: () => true,
-    onRemove: () => {}
+    onRemove: () => { }
   });
   // make sure datacore has access to it for pure data manipulation
   SetTrackerRP(RP_PTRAK_TO_VOBJ);

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-costume.ts
@@ -174,6 +174,8 @@ function m_Update(frame) {
     // Set GLOW
     if (agent.prop.Costume.glow.value > 0) {
       agent.prop.Costume.glow.sub(1 / SIM_TICKS_PER_SEC); // frame rate
+      if (agent.prop.Costume.glowColor.value !== undefined)
+        agent.prop.glowColor.setTo(agent.prop.Costume.glowColor.value);
       agent.isGlowing = true;
     } else {
       agent.isGlowing = false;
@@ -279,9 +281,13 @@ class CostumePack extends SM_Feature {
     //         to enable applicaiton of flip?
     this.featAddProp(agent, 'flipX', new SM_Boolean(false));
     this.featAddProp(agent, 'flipY', new SM_Boolean(false));
-    // Costume color will override agent color during m_Update
     prop = new SM_Number();
     this.featAddProp(agent, 'glow', prop); // in seconds
+    prop = new SM_Number();
+    prop.setMax(16777215);
+    prop.setMin(0);
+    this.featAddProp(agent, 'glowColor', prop);
+    // Costume color will override agent color during m_Update
     prop = new SM_Number();
     prop.setMax(16777215);
     prop.setMin(0);
@@ -550,6 +556,7 @@ class CostumePack extends SM_Feature {
       flipX: SM_Boolean.Symbols,
       flipY: SM_Boolean.Symbols,
       glow: SM_Number.Symbols,
+      glowColor: SM_Number.Symbols,
       color: SM_Number.Symbols, // hex css
       colorHue: SM_Number.Symbols,
       colorSaturation: SM_Number.Symbols,

--- a/gs_packages/gem-srv/src/modules/sim/sim-agents.js
+++ b/gs_packages/gem-srv/src/modules/sim/sim-agents.js
@@ -40,6 +40,7 @@ AGENT_TO_DOBJ.setMapFunctions({
     dobj.zIndex = agent.zIndex !== undefined ? agent.zIndex : 0;
     if (agent.skin) dobj.skin = agent.skin;
     dobj.color = agent.color; // always copy color, set color = undefined to clear filters
+    if (agent.prop.glowColor.value !== undefined) dobj.glowColor = agent.prop.glowColor.value;
     if (agent.prop.Costume) dobj.frame = agent.prop.Costume.currentFrame.value;
     if (agent.scale !== undefined) dobj.scale = agent.scale;
     if (agent.scaleY !== undefined) dobj.scaleY = agent.scaleY;
@@ -72,6 +73,7 @@ AGENT_TO_DOBJ.setMapFunctions({
     dobj.zIndex = agent.zIndex !== undefined ? agent.zIndex : 0;
     if (agent.skin) dobj.skin = agent.skin;
     dobj.color = agent.color; // always copy color, set color = undefined to clear filters
+    if (agent.prop.glowColor.value !== undefined) dobj.glowColor = agent.prop.glowColor.value;
     if (agent.prop.Costume) dobj.frame = agent.prop.Costume.currentFrame.value;
     if (agent.scale !== undefined) dobj.scale = agent.scale;
     if (agent.scaleY !== undefined) dobj.scaleY = agent.scaleY;
@@ -226,7 +228,7 @@ function FilterBlueprints(namesToKeep) {
 
 /// PROGRAMMING INTERFACE /////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function AgentSelect() {}
+function AgentSelect() { }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** placeholder function
  *  Main update


### PR DESCRIPTION
This adds the ability to set a `glowColor` for characters.

Features:
* Each character has their own glow filter, so they can all have unique colors.
* A character's glow color can change at any time during the update cycle, so the character can change from blue to green, etc.
* The glow color defaults to yellow if `glowColor` is not set.  
* To save on bandwidth, `glowColor` is not passed to the renderer if `agent.prop.glowColor` has not been set.
* The agent uses an internal property `agent.prop.glowColor` to track `glowColor` if it's been set.  This allows us to set up other features or use other techniques to set glow.  This should not be set directly as the Costume feature will override the value during the update cycle.
* The `Costume` Feature is the preferred way to set `glowColor`.  The `glowColor` is applied during the Costume feature update cycle.

# TO USE
```
featProp character.Costume.glow setTo 0.2
featProp character.Costume.glowColor setToColor 15597823
```

Addresses #782 