### PR TITLE
Feature: Text Styles (Partial Implementation)

### DIFF
--- a/gs_packages/gem-srv/src/app/help/codex-features.yaml
+++ b/gs_packages/gem-srv/src/app/help/codex-features.yaml
@@ -45,6 +45,20 @@ Graphing:
     info: 'Set a bar graph to the value of this property and update the graph when the property does.'
   barGraphPropFeature:
     info: 'Help for barGraphPropFeature coming soon.'
+  textAlign:
+    info: 'Text alignment. Settings, which can be combined are TOP: 1, MIDDLE: 2, BOTTOM: 4, LEFT: 8, CENTER: 16, RIGHT: 32.'
+  textAlignment:
+    name: 'textAlignment'
+    input: 'Settings, which can be combined are TOP: 1, MIDDLE: 2, BOTTOM: 4, LEFT: 8, CENTER: 16, RIGHT: 32.'
+    info: 'Settings, which can be combined are TOP: 1, MIDDLE: 2, BOTTOM: 4, LEFT: 8, CENTER: 16, RIGHT: 32.'
+  textJustify:
+    info: 'Text alignment. Settings are LEFT: 1, CENTER: 2, RIGHT: 4.'
+  textJustification:
+    name: 'textAlignment'
+    input: 'Text alignment. Settings are LEFT: 1, CENTER: 2, RIGHT: 4.'
+    info: 'Text alignment. Settings are LEFT: 1, CENTER: 2, RIGHT: 4.'
+  textColor:
+    info: 'Text color. Use setToColor for options'
   # Graphing methods
   showMessage:
     info: 'This creates a popup message for the users to read.'

--- a/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
+++ b/gs_packages/gem-srv/src/app/pages/wiz/gui/EditSymbol_Block.tsx
@@ -115,6 +115,8 @@ export const ADVANCED_SYMBOLS = [
   'getHSVColorScaleColor',
   'wordWrapWidth',
   'fontSize',
+  'textAlign',
+  'textJustify',
   // movement
   'bounceAngle',
   'setRandomPositionX',

--- a/gs_packages/gem-srv/src/lib/class-visual.ts
+++ b/gs_packages/gem-srv/src/lib/class-visual.ts
@@ -108,6 +108,9 @@ class Visual implements IVisual, IPoolable, IActable {
   filterbox: PIXI.Container; // Filters are applied to everything in this container
   sprite: PIXI.Sprite;
   text: PIXI.Text;
+  textAlign: number;
+  textJustify: number;
+  textColor: number;
   meter: PIXI.Graphics;
   graph: PIXI.Graphics;
   cone: PIXI.Graphics;
@@ -149,6 +152,9 @@ class Visual implements IVisual, IPoolable, IActable {
       outerStrength: 3,
       color: 0xffff00
     });
+    this.textAlign = 20; // bottom centered
+    this.textJustify = 2; // centered
+    this.textColor = 0xffffff; // white
     this.isSelected = false; // use primary selection effect
     this.isHovered = false; // use secondary highlight effect
     this.isGrouped = false; // use tertiary grouped effect
@@ -429,6 +435,18 @@ class Visual implements IVisual, IPoolable, IActable {
       //    We have to remove the child and reset it to update the text?
       this.container.removeChild(this.text);
       if (this.text) this.text.destroy();
+
+      // Update Style
+      this.style.fill = [PIXI.utils.hex2string(this.textColor)]; // [`#${(this.textColor, 16)}CC`];
+
+      // Justification only for multiline texts -- does not affect single lines
+      // To justify single line text, use textAlign
+      let justify;
+      if (this.textJustify & FLAGS.JUSTIFICATION.LEFT) justify = 'left';
+      if (this.textJustify & FLAGS.JUSTIFICATION.CENTER) justify = 'center';
+      if (this.textJustify & FLAGS.JUSTIFICATION.RIGHT) justify = 'right';
+      this.style.align = justify;
+
       // -- Create new text
       this.text = new PIXI.Text(str, this.style);
 
@@ -436,13 +454,33 @@ class Visual implements IVisual, IPoolable, IActable {
       this.container.addChild(this.text);
     }
     if (this.text) {
-      // position text bottom centered
       const width = this.text.width;
       const spacer = 5;
-      const x = -width / 2; //this.sprite.width; // for some reason text is offset?
-      const y = this.sprite.height / 2 + spacer;
+
+      let x, y;
+      if (this.textAlign & FLAGS.ALIGNMENT.TOP)
+        y = -this.sprite.height / 2 + spacer;
+      if (this.textAlign & FLAGS.ALIGNMENT.MIDDLE) y = -this.text.height / 2;
+      if (this.textAlign & FLAGS.ALIGNMENT.BOTTOM)
+        y = this.sprite.height / 2 + spacer;
+      if (this.textAlign & FLAGS.ALIGNMENT.LEFT) x = -width;
+      if (this.textAlign & FLAGS.ALIGNMENT.CENTER) x = -width / 2; // for some reason text is offset?
+      if (this.textAlign & FLAGS.ALIGNMENT.RIGHT)
+        x = this.sprite.width / 2 - width;
+
       this.text.position.set(x, y);
     }
+  }
+  // Uses FLAGS.ALIGNMENT
+  setTextAlign(alignment: number) {
+    this.textAlign = alignment;
+  }
+  // Uses FLAGS.JUSTIFICATION
+  setTextJustify(justification: number) {
+    this.textJustify = justification;
+  }
+  setTextColor(color: number) {
+    this.textColor = color;
   }
 
   setTextStyle(key: string, value: string | number) {

--- a/gs_packages/gem-srv/src/lib/class-visual.ts
+++ b/gs_packages/gem-srv/src/lib/class-visual.ts
@@ -443,7 +443,6 @@ class Visual implements IVisual, IPoolable, IActable {
       this.container.addChild(this.text);
     }
     if (this.text) {
-      const width = this.text.width;
       const spacer = 5;
 
       // Update Style
@@ -457,16 +456,20 @@ class Visual implements IVisual, IPoolable, IActable {
 
       let x, y;
       if (this.textAlign & FLAGS.ALIGNMENT.TOP)
-        y = -this.sprite.height / 2 + spacer;
-      if (this.textAlign & FLAGS.ALIGNMENT.MIDDLE) y = -this.text.height / 2;
+        y = -this.sprite.height / 2 - this.text.height / 2;
+      if (this.textAlign & FLAGS.ALIGNMENT.MIDDLE) y = 0;
       if (this.textAlign & FLAGS.ALIGNMENT.BOTTOM)
-        y = this.sprite.height / 2 + spacer;
-      if (this.textAlign & FLAGS.ALIGNMENT.LEFT) x = -width;
-      if (this.textAlign & FLAGS.ALIGNMENT.CENTER) x = -width / 2; // for some reason text is offset?
+        y = this.sprite.height / 2 + this.text.height / 2;
+      if (this.textAlign & FLAGS.ALIGNMENT.LEFT)
+        x = -this.sprite.width / 2 - this.text.width / 2;
+      if (this.textAlign & FLAGS.ALIGNMENT.CENTER) x = 0;
       if (this.textAlign & FLAGS.ALIGNMENT.RIGHT)
-        x = this.sprite.width / 2 - width;
-
+        x = this.sprite.width / 2 + this.text.width / 2;
       this.text.position.set(x, y);
+      this.text.anchor.set(0.5, 0.5);
+
+      // update color
+      this.style.fill = [PIXI.utils.hex2string(this.textColor)];
     }
   }
   // Uses FLAGS.ALIGNMENT

--- a/gs_packages/gem-srv/src/lib/class-visual.ts
+++ b/gs_packages/gem-srv/src/lib/class-visual.ts
@@ -436,17 +436,6 @@ class Visual implements IVisual, IPoolable, IActable {
       this.container.removeChild(this.text);
       if (this.text) this.text.destroy();
 
-      // Update Style
-      this.style.fill = [PIXI.utils.hex2string(this.textColor)]; // [`#${(this.textColor, 16)}CC`];
-
-      // Justification only for multiline texts -- does not affect single lines
-      // To justify single line text, use textAlign
-      let justify;
-      if (this.textJustify & FLAGS.JUSTIFICATION.LEFT) justify = 'left';
-      if (this.textJustify & FLAGS.JUSTIFICATION.CENTER) justify = 'center';
-      if (this.textJustify & FLAGS.JUSTIFICATION.RIGHT) justify = 'right';
-      this.style.align = justify;
-
       // -- Create new text
       this.text = new PIXI.Text(str, this.style);
 
@@ -456,6 +445,15 @@ class Visual implements IVisual, IPoolable, IActable {
     if (this.text) {
       const width = this.text.width;
       const spacer = 5;
+
+      // Update Style
+      // Justification only for multiline texts -- does not affect single lines
+      // To justify single line text, use textAlign
+      let justify;
+      if (this.textJustify & FLAGS.JUSTIFICATION.LEFT) justify = 'left';
+      if (this.textJustify & FLAGS.JUSTIFICATION.CENTER) justify = 'center';
+      if (this.textJustify & FLAGS.JUSTIFICATION.RIGHT) justify = 'right';
+      this.style.align = justify;
 
       let x, y;
       if (this.textAlign & FLAGS.ALIGNMENT.TOP)

--- a/gs_packages/gem-srv/src/modules/flags.js
+++ b/gs_packages/gem-srv/src/modules/flags.js
@@ -24,6 +24,19 @@ FLAGS.POSITION = {
   INSIDE_RIGHT: 8,
   OUTSIDE_RIGHT: 16
 };
+FLAGS.ALIGNMENT = {
+  TOP: 1,
+  MIDDLE: 2,
+  BOTTOM: 4,
+  LEFT: 8,
+  CENTER: 16,
+  RIGHT: 32
+};
+FLAGS.JUSTIFICATION = {
+  LEFT: 1,
+  CENTER: 2,
+  RIGHT: 4
+};
 
 /// MODULE EXPORTS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/gs_packages/gem-srv/src/modules/flags.js
+++ b/gs_packages/gem-srv/src/modules/flags.js
@@ -24,6 +24,7 @@ FLAGS.POSITION = {
   INSIDE_RIGHT: 8,
   OUTSIDE_RIGHT: 16
 };
+// text alignment relative to center of character
 FLAGS.ALIGNMENT = {
   TOP: 1,
   MIDDLE: 2,
@@ -32,6 +33,7 @@ FLAGS.ALIGNMENT = {
   CENTER: 16,
   RIGHT: 32
 };
+// character text justification for multiple rows of text
 FLAGS.JUSTIFICATION = {
   LEFT: 1,
   CENTER: 2,

--- a/gs_packages/gem-srv/src/modules/render/api-render.js
+++ b/gs_packages/gem-srv/src/modules/render/api-render.js
@@ -133,6 +133,15 @@ function Init(element) {
       vobj.setColorize(dobj.color);
       vobj.applyFilters();
 
+      //setup the text properties
+      if (dobj.fontSize != undefined)
+        vobj.setTextStyle('fontSize', dobj.fontSize);
+      if (dobj.wordWrapWidth != undefined)
+        vobj.setTextStyle('wordWrapWidth', dobj.wordWrapWidth);
+      if (dobj.textAlign != undefined) vobj.setTextAlign(dobj.textAlign);
+      if (dobj.textJustify != undefined) vobj.setTextJustify(dobj.textJustify);
+      if (dobj.textColor != undefined) vobj.setTextColor(dobj.textColor);
+
       if (dobj.debug) vobj.setDebug(dobj.debug);
 
       // Old Approach: Only enable drag and hover if controlMode is puppet (1)
@@ -213,6 +222,9 @@ function Init(element) {
         vobj.setTextStyle('fontSize', dobj.fontSize);
       if (dobj.wordWrapWidth != undefined)
         vobj.setTextStyle('wordWrapWidth', dobj.wordWrapWidth);
+      if (dobj.textAlign != undefined) vobj.setTextAlign(dobj.textAlign);
+      if (dobj.textJustify != undefined) vobj.setTextJustify(dobj.textJustify);
+      if (dobj.textColor != undefined) vobj.setTextColor(dobj.textColor);
 
       if (dobj.debug) vobj.setDebug(dobj.debug);
       else vobj.removeDebug();

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
@@ -251,6 +251,10 @@ class WidgetPack extends SM_Feature {
     prop.addOption('center', FLAGS.ALIGNMENT.CENTER);
     prop.addOption('right', FLAGS.ALIGNMENT.RIGHT);
     this.featAddProp(agent, 'textAlign', prop);
+    prop = new SM_Number();
+    prop.addOption('left', FLAGS.JUSTIFICATION.LEFT);
+    prop.addOption('center', FLAGS.JUSTIFICATION.CENTER);
+    prop.addOption('right', FLAGS.JUSTIFICATION.RIGHT);
     this.featAddProp(agent, 'textJustify', prop);
     prop = new SM_Number();
     prop.setMax(16777215);

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
@@ -358,8 +358,12 @@ class WidgetPack extends SM_Feature {
         setTo: ['labelString:string']
       }),
       textProp: SM_String.Symbols,
-      textAlign: SM_Number.Symbols,
-      textJustify: SM_Number.Symbols,
+      textAlign: SM_Number.SymbolizeCustom({
+        setTo: ['textAlignment:number']
+      }),
+      textJustify: SM_Number.SymbolizeCustom({
+        setTo: ['textJustification:number']
+      }),
       textColor: SM_Number.Symbols,
       meter: SM_Number.Symbols,
       meterProp: SM_String.SymbolizeCustom({

--- a/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
+++ b/gs_packages/gem-srv/src/modules/sim/features/feat-graphing.ts
@@ -243,8 +243,21 @@ class WidgetPack extends SM_Feature {
 
     this.featAddProp(agent, 'text', new SM_String(agent.name)); // default to agent name
     this.featAddProp(agent, 'textProp', new SM_String()); // agent prop name that text is bound to
-
     let prop = new SM_Number();
+    prop.addOption('top', FLAGS.ALIGNMENT.TOP);
+    prop.addOption('middle', FLAGS.ALIGNMENT.MIDDLE);
+    prop.addOption('bottom', FLAGS.ALIGNMENT.BOTTOM);
+    prop.addOption('left', FLAGS.ALIGNMENT.LEFT);
+    prop.addOption('center', FLAGS.ALIGNMENT.CENTER);
+    prop.addOption('right', FLAGS.ALIGNMENT.RIGHT);
+    this.featAddProp(agent, 'textAlign', prop);
+    this.featAddProp(agent, 'textJustify', prop);
+    prop = new SM_Number();
+    prop.setMax(16777215);
+    prop.setMin(0);
+    this.featAddProp(agent, 'textColor', prop);
+
+    prop = new SM_Number();
     prop.setMax(1);
     prop.setMin(0);
     this.featAddProp(agent, 'meter', prop);
@@ -341,6 +354,9 @@ class WidgetPack extends SM_Feature {
         setTo: ['labelString:string']
       }),
       textProp: SM_String.Symbols,
+      textAlign: SM_Number.Symbols,
+      textJustify: SM_Number.Symbols,
+      textColor: SM_Number.Symbols,
       meter: SM_Number.Symbols,
       meterProp: SM_String.SymbolizeCustom({
         setTo: ['propertyName:string']

--- a/gs_packages/gem-srv/src/modules/sim/sim-agents.js
+++ b/gs_packages/gem-srv/src/modules/sim/sim-agents.js
@@ -65,6 +65,9 @@ AGENT_TO_DOBJ.setMapFunctions({
     if (agent.prop.Graphing !== undefined) {
       dobj.fontSize = agent.prop.Graphing.fontSize.value;
       dobj.wordWrapWidth = agent.prop.Graphing.wordWrapWidth.value;
+      dobj.textAlign = agent.prop.Graphing.textAlign.value;
+      dobj.textJustify = agent.prop.Graphing.textJustify.value;
+      dobj.textColor = agent.prop.Graphing.textColor.value;
     }
   },
   onUpdate: (agent, dobj) => {
@@ -93,6 +96,13 @@ AGENT_TO_DOBJ.setMapFunctions({
     if (agent.statusObject !== undefined) {
       dobj.barGraph = agent.statusObject.barGraph;
       dobj.barGraphLabels = agent.statusObject.barGraphLabels;
+    }
+    if (agent.prop.Graphing !== undefined) {
+      dobj.fontSize = agent.prop.Graphing.fontSize.value;
+      dobj.wordWrapWidth = agent.prop.Graphing.wordWrapWidth.value;
+      dobj.textAlign = agent.prop.Graphing.textAlign.value;
+      dobj.textJustify = agent.prop.Graphing.textJustify.value;
+      dobj.textColor = agent.prop.Graphing.textColor.value;
     }
   }
 });


### PR DESCRIPTION
Addresses #783 

This partially implements styling for character text.

Due to the complexity of implementing selection menu options for wizards, it is not possible at this time to use a selection menu to select alignment and justification values.  Instead, you'll have to use a bitwise flags to combine settings.

The Graphing feature now has three feature properties:
* `textAlign`
* `textJustfication`
* `textColor`

To set text alignment:
```
addFeature Graphing
featProp character.Graphing.text setTo "Fish Under The Seam"
featProp character.Graphing.textAlign setTo 18
featProp character.Graphing.textJustification setTo 1
featProp character.Graphing.textColor setToColor 16768256 
```

Notes
* We use bitwise flags to set alignment and justification values to minimize the data footprint when sending visual data across the network.
* The ability to select an alignment/justification value via `setToOption` will be added in the future once we add support for defining and using built-in gvars options for features.


# Alignment

Alignments are set via bitwise flags that you can combine to determine the position.  e.g. to set `TOP` use `1`; e.g. to use `TOP + CENTER` add `CENTER: 16` to `TOP: 1` or `17`.  Use the table below for convenience.

```
featProp character.Graphing.textAlign setTo 18
```


Labels are set to appear just outside of the sprite bounding box so they don't cover the sprite.  The exception is the MIDDLE + CENTER value which will appear in the middle of the sprite.

The default alignment is BOTTOM + CENTER.

```
TOP: 1         
MIDDLE: 2   // vertical
BOTTOM: 4
LEFT: 8
CENTER: 16  // horizontal
RIGHT: 32
```
 
| | alignment values | |
|---|---|---|
| TOP LEFT: 9 | TOP CENTER: 17 | TOP RIGHT: 33 |
| MIDDLE LEFT: 10 | MIDDLE CENTER: 18 | MIDDLE RIGHT: 34 |
| BOTTOM LEFT: 12 | BOTTOM CENTER: 20 | BOTTOM RIGHT: 36 |


# Justification
Justification only works for multiline text.  

```
featProp character.Graphing.textJustification setTo 1
```

The default justification is CENTER.
```
LEFT: 1
CENTER: 2
RIGHT: 4
```


# Color

Use the `setToColor` method to enable the color picker.
Previously we applied a slightly transparent alpha to the text to soften the text, but the color picker does not allow alphas.

```
featProp character.Graphing.textColor setToColor 16768256 
```



---
Note to Future Ben for reference: See [2023-01107-wip-text-styles c86cae8](c86cae8c95ee838c1021eb152084eb09a48eb0bd) stash for how SlotEditor_Block might handle options in built-in features gvar options.
* See also #799 on better handling gvar options
* See also notes on #783 on handling visual agent modeling