### PR TITLE
Feature: Select Default Pozyx Controlled Character

### DIFF
--- a/gs_packages/gem-srv/src/app/pages/components/PanelProjectEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelProjectEditor.jsx
@@ -28,8 +28,7 @@ class ProjectEditor extends React.Component {
     super();
     this.state = {
       project: undefined,
-      isBeingEdited: false,
-      needsReset: false
+      isBeingEdited: false
     };
     this.urStateUpdated = this.urStateUpdated.bind(this);
     this.UIFormInputUpdate = this.UIFormInputUpdate.bind(this);
@@ -76,6 +75,8 @@ class ProjectEditor extends React.Component {
       return boolstr.toLowerCase().trim() === 'true';
     }
 
+    // 'id' and 'label' are `projectData`
+    // everything else is `metaData`
     let isMetaData = false;
     const { project } = this.state;
     if (e.target.id === 'id') {
@@ -101,13 +102,14 @@ class ProjectEditor extends React.Component {
   UIDefaultCharacterSelect(event) {
     const { project } = this.state;
     project.metadata.defaultCharacter = event.target.value;
-    this.setState({ project, needsReset: true }, () => {
+    this.setState({ project }, () => {
       this.SaveMetaData();
+      UR.RaiseMessage('ENTITIES_RESET');
     });
   }
 
   OnPanelClick(id) {
-    console.log('click', id); // e, e.target, e.target.value);
+    console.log('click', id);
   }
 
   EditProject() {
@@ -116,10 +118,8 @@ class ProjectEditor extends React.Component {
   }
 
   EndEditProject() {
-    const { needsReset } = this.state;
-    if (needsReset) UR.RaiseMessage('ENTITIES_RESET');
     UR.LogEvent('ProjSetup', ['Project Settings Save']);
-    this.setState({ isBeingEdited: false, needsReset: false });
+    this.setState({ isBeingEdited: false });
   }
 
   SaveProjectData() {
@@ -238,7 +238,7 @@ class ProjectEditor extends React.Component {
                 onClick={this.EndEditProject}
                 className={classes.button}
               >
-                Save Project Settings
+                Close Project Settings
               </button>
             </div>
           </div>

--- a/gs_packages/gem-srv/src/app/pages/components/PanelProjectEditor.jsx
+++ b/gs_packages/gem-srv/src/app/pages/components/PanelProjectEditor.jsx
@@ -221,7 +221,7 @@ class ProjectEditor extends React.Component {
                 onChange={this.UIDefaultCharacterSelect}
                 className="form-control"
               >
-                <option value={undefined}>-- select a character --</option>
+                <option value={''}>-- select a character --</option>
                 {pozyxBpNames.map(bpName => (
                   <option key={bpName} value={bpName}>
                     {bpName}

--- a/gs_packages/gem-srv/src/app/pages/helpers/project-server.js
+++ b/gs_packages/gem-srv/src/app/pages/helpers/project-server.js
@@ -348,6 +348,20 @@ function InjectBlueprint(data) {
   ACBlueprints.InjectBlueprint(CURRENT_PROJECT_ID, blueprint);
 }
 
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API: Force reset of input definitions after changing default pozyx character
+ *       If the project metadata.defaultCharacter has changed we need to reset
+ *       the inputs, otherwise the old defaultCharacter will be retained
+*/
+function EntitiesReset() {
+  // HACK Force Project Reload
+  // Pozyx inputs need to be reset otherwise the old character will continue to
+  // be used.  The proper fix is add support to pools to reset the pool.
+  // See #801
+  setTimeout(() => location.reload(true), 1000);
+  // The timeout gives the system time to reset the inputs.
+}
+
 /// TRANSFORM UTILITIES ///////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function HandleTransformReq() {
@@ -593,7 +607,7 @@ function InstanceRequestEdit(data) {
   }
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/** API: User has edited the instance  using the InstanceEditor.
+/** API: User has edited the instance using the InstanceEditor.
  *  This usually means the instance name and/or the instance initScript
  *  has changed.
  *  The state has already been updated.
@@ -840,6 +854,8 @@ UR.HandleMessage('METADATA_UPDATE', UpdateMetadata);
 UR.HandleMessage('NET:SCRIPT_UPDATE', ScriptUpdate);
 UR.HandleMessage('NET:BLUEPRINT_DELETE', HandleBlueprintDelete);
 UR.HandleMessage('INJECT_BLUEPRINT', InjectBlueprint);
+///
+UR.HandleMessage('ENTITIES_RESET', EntitiesReset);
 /// INSTANCE EDITING UTILS ----------------------------------------------------
 UR.HandleMessage('LOCAL:INSTANCE_ADD', InstanceAdd);
 UR.HandleMessage('NET:INSTANCE_UPDATE', InstanceUpdate);
@@ -874,6 +890,8 @@ export {
   DoUnRegisterInspector, // <- NET:INSPECTOR_UNREGISTER { id }
   //
   InjectBlueprint, // <- INJECT_BLUEPRINT
+  //
+  EntitiesReset,
   //
   BlueprintDelete, // <- NET:BLUEPRINT_DELETE { blueprintId, modelName }
   //

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -246,6 +246,9 @@ function GetBpNamesList(): string[] {
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function GetDefaultInputBpName(type?: string): string {
+  // NOTE if a type is not selected, the default reverts back to the
+  // `STATE._getKey('defaultBpName')`, which is the first non-global blueprint
+  // found (set as a derived value in  m_UpdateAndPublishDerivedBpLists)
   switch (type) {
     case TYPES.Pozyx:
       return GetPozyxControlDefaultBpName();

--- a/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-blueprints.ts
@@ -245,7 +245,7 @@ function GetBpNamesList(): string[] {
   return STATE._getKey('bpNamesList');
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function GetDefaultInputBpName(type: string): string {
+function GetDefaultInputBpName(type?: string): string {
   switch (type) {
     case TYPES.Pozyx:
       return GetPozyxControlDefaultBpName();
@@ -342,8 +342,8 @@ function m_GeneratePozyxControlBpNames(bundles: SM_Bundle[]): string[] {
 function GetPozyxControlBpNames(): string[] {
   return STATE._getKey('pozyxControlBpNames');
 }
-/** API: Returns the first pozyx controllable blueprint name as the default bp to use
- *  Used dc-inputs to determine mapping
+/** API: Returns a random pozyx controllable blueprint name as the default bp to use
+ *  Uses dc-inputs to determine mapping
  *  @returns {string} - bpName
  */
 function GetPozyxControlDefaultBpName(): string {

--- a/gs_packages/gem-srv/src/modules/appcore/ac-metadata.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-metadata.ts
@@ -190,13 +190,24 @@ function Wraps(wall = 'any') {
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-/** If defaultCharacter is not defined for the project, fall back to selecting
- *  a random blueprint.
+/** If defaultCharacter is defined, use that.
+ *  Else if defaultCharacter is not defined,'
+ *  then if a default pozyx-controllable character is available, use a random
+ *  pozyx-controllable character.
+ *  Else if no default is definedfor the project, fall back to selecting
+ *  the ac-metadata defined `defaultBpName` blueprint.
+ *  To force the selection of a random **pozyx-controllable** character, change
+ *  the `ACBlueprints.GetDefaultInputBpName();` call to
+ *  `ACBlueprints.GetPozyxControlDefaultBpName`
  */
 function GetDefaultBp() {
   const metadata = _getKey('metadata');
   if (metadata.defaultCharacter) return metadata.defaultCharacter;
-  else return ACBlueprints.GetDefaultInputBpName();
+  else {
+    const defaultPoxyBpName = ACBlueprints.GetPozyxControlDefaultBpName();
+    if (defaultPoxyBpName) return defaultPoxyBpName;
+    return ACBlueprints.GetDefaultInputBpName();
+  }
 }
 
 /// UPDATERS //////////////////////////////////////////////////////////////////

--- a/gs_packages/gem-srv/src/modules/appcore/ac-metadata.ts
+++ b/gs_packages/gem-srv/src/modules/appcore/ac-metadata.ts
@@ -7,6 +7,7 @@
 
 import UR from '@gemstep/ursys/client';
 import * as DCPROJECT from 'modules/datacore/dc-project';
+import * as ACBlueprints from './ac-blueprints';
 import ERROR from 'modules/error-mgr';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
@@ -28,6 +29,7 @@ STATE.initializeState({
       bounce: false,
       bgcolor: '0x006666',
       roundsCanLoop: false,
+      defaultCharacter: undefined,
       // webcam settings
       showWebCam: true,
       scaleX: 1,
@@ -186,6 +188,17 @@ function Wraps(wall = 'any') {
   }
 }
 
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+/** If defaultCharacter is not defined for the project, fall back to selecting
+ *  a random blueprint.
+ */
+function GetDefaultBp() {
+  const metadata = _getKey('metadata');
+  if (metadata.defaultCharacter) return metadata.defaultCharacter;
+  else return ACBlueprints.GetDefaultInputBpName();
+}
+
 /// UPDATERS //////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -207,6 +220,10 @@ function SetMetadata(projId, metadata) {
   metadata.rotate = metadata.rotate !== undefined ? metadata.rotate : 0;
   metadata.mirrorX = metadata.mirrorX !== undefined ? metadata.mirrorX : false;
   metadata.mirrorY = metadata.mirrorY !== undefined ? metadata.mirrorY : false;
+  metadata.defaultCharacter =
+    metadata.defaultCharacter !== undefined
+      ? metadata.defaultCharacter
+      : undefined;
 
   // Update datacore
   DCPROJECT.UpdateProjectData({ metadata });
@@ -226,4 +243,4 @@ function SetMetadata(projId, metadata) {
 
 /// EXPORTS ///////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-export { GetMetadata, GetBoundary, Wraps, SetMetadata };
+export { GetMetadata, GetBoundary, Wraps, GetDefaultBp, SetMetadata };

--- a/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
+++ b/gs_packages/gem-srv/src/modules/datacore/dc-inputs.ts
@@ -17,6 +17,7 @@
 import UR from '@gemstep/ursys/client';
 import * as ACBlueprints from 'modules/appcore/ac-blueprints';
 import * as ACInstances from 'modules/appcore/ac-instances';
+import * as ACMetaData from 'modules/appcore/ac-metadata';
 import InputDef from 'lib/class-input-def';
 import SyncMap from 'lib/class-syncmap';
 import * as DCAGENTS from './dc-sim-agents';
@@ -248,7 +249,8 @@ ENTITY_TO_COBJ.setMapFunctions({
     cobj.x = x;
     cobj.y = y;
 
-    cobj.bpid = ACBlueprints.GetDefaultInputBpName(entity.type);
+    cobj.bpid = ACMetaData.GetDefaultBp();
+
     // If user has selected a different bp for tags (pozyx, ptrack), use the override
     const tagBpid = ACInstances.GetTagBpid(cobj.id);
     if (tagBpid !== undefined) cobj.bpid = tagBpid;


### PR DESCRIPTION
Addresses #784.

This adds the ability to select a default character type as the starting character type for all new pozyx tags entering the simulation.

![screenshot_1355](https://github.com/theRAPTLab/gsgo/assets/1403057/0d6c410e-b767-47b8-9fac-db9fd8ca5b29)


NOTES:
* By default, project metadata settings will not set a "default character".  If a "default character" is not defined for the project, the system will try this in order:
   a. select a random pozyx-controllable character
   b. select the first non-global character type as the starting character type for any new pozyx tag, regardless of whether it is `pozyx-controllable`.  This way a character is always selected even though the "CHARACTER CONTROLLERS" display will show a blank character type.
* After a default character is set ~and the project settings are saved~, the project page will reload in order to force the input system to reset and load the new default character.

#  TO TEST

No pozyx-controllable characters defined
1. For all character types, set `# TAG isPozyxControllable **false**`
2. Reload the project
3. Select project "SETUP"
4. Click "Edit Project Settings"
5. Open the "default character" menu: the menu should only show "-- select a character --", and there should be no character types available to choose.
6. The first non-global character type will be selected for all pozyx tags even though there are no `pozyx-controllable` characters.  This is to ensure that SOMETHING is selected.

One pozyx-controllable character defined
1. For a single character type, set `# TAG isPozyxControllable **true**`
2. Reload the project
3. Select project "SETUP"
4. Click "Edit Project Settings"
5. Open the "default character" menu: the menu should show the character.
7. Select the "default character" type.
8. ~Click "Save Project Settings"~
9. The Main page will reload.
10. Any pozyx tag should be set to the default character type

More than one pozyx-controllable characters defined
1. Do the same thing, only this time enabling multiple character types to be `isPozyxControllable`
2. Open the "default character" menu: the menu should show all of the available character types.
7. Select a "default character" type.
8. ~Click "Save Project Settings"~
9. The Main page will reload.
11. Any pozyx tag should be set to the default character type

Character Type Script is removed
1. Leaving multiple character types `isPozyxControllable` enabled...
2. Delete character type you had previously set as the default
3. Select project "SETUP"
4. Click "Edit Project Settings"
5. Open the "default character" menu: the menu should show "-- select a character --", meaning no default is selected.
6. You actually have to reload the project ~or click "Save Project Settings" and "Save" the SETUP to return to the menu~.
7. NOTE that the existing removed pozyx character type will actually remain until you reload the project.

No default defined
1. Leaving multiple character types `isPozyxControllable` enabled...
2. Select project "SETUP"
3. Click "Edit Project Settings"
4. Select "-- select a character --" to clear the default character type.
8. ~Click "Save Project Settings"~
9. The Main page should reload.  The default pozyx tag should be randomly selected from the list of available `isPozyxControllable`characters.

